### PR TITLE
fix build with g++ (Ubuntu 12.2.0-17ubuntu1) 12.2.0

### DIFF
--- a/src/include/AsmFile.h
+++ b/src/include/AsmFile.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <wjakob/filesystem/path.h>
 #include <Utils.h>
+#include <iterator> 
 
 class AsmFile
 {


### PR DESCRIPTION
I am using g++ (Ubuntu 12.2.0-17ubuntu1) 12.2.0, when make I have this error: 
src/AsmFile.cpp:160:38: error: ‘istream_iterator’ is not a member of ‘std’
this little MR simply add <iterator> header to AsmFile.h so it compiles under linux 