### PR TITLE
include cstdint to define uint8_t

### DIFF
--- a/src/landstalker/misc/include/Utils.h
+++ b/src/landstalker/misc/include/Utils.h
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <vector>
 #include <cassert>
+#include <cstdint>
 #include <wjakob/filesystem/path.h>
 
 void Debug(const std::string& message);

--- a/src/user_interface/rooms/include/LayerControlFrame.h
+++ b/src/user_interface/rooms/include/LayerControlFrame.h
@@ -4,6 +4,7 @@
 #include <wx/wx.h>
 #include <array>
 #include <vector>
+#include <cstdint>
 
 class LayerControlFrame : public wxWindow
 {


### PR DESCRIPTION
When compile I have the error `error: 'uint8_t' has not been declared`, this PR simply include cstdint to define uint8_t