### PR TITLE
Fix segfault issue on Ubuntu.

### DIFF
--- a/src/landstalker/main/src/AsmFile.cpp
+++ b/src/landstalker/main/src/AsmFile.cpp
@@ -265,7 +265,7 @@ void AsmFile::WriteFileHeader(const filesystem::path& p, const std::string& shor
 	*this << AsmFile::Comment(PrintCentered(short_description));
 	*this << AsmFile::Comment(PrintCentered(p.str()));
 	*this << AsmFile::Comment(PrintCentered(""));
-	*this << AsmFile::Comment(PrintCentered("Generated using the Landstalker Editor v0.3.3:"));
+	*this << AsmFile::Comment(PrintCentered("Generated using the Landstalker Editor v0.3.4:"));
 	*this << AsmFile::Comment(PrintCentered("https://github.com/lordmir/landstalker_editor"));
 	*this << AsmFile::Comment(PrintCentered("For use with the Landstalker disassembly:"));
 	*this << AsmFile::Comment(PrintCentered("https://github.com/lordmir/landstalker_disasm"));

--- a/src/user_interface/2d_maps/src/Map2DEditorFrame.cpp
+++ b/src/user_interface/2d_maps/src/Map2DEditorFrame.cpp
@@ -737,11 +737,11 @@ void Map2DEditorFrame::OnMenuClick(wxMenuEvent& evt)
 
 void Map2DEditorFrame::ClearMenu(wxMenuBar& menu) const
 {
-	EditorFrame::ClearMenu(menu);
 	// The toolbar destructor deletes these, but doesn't clear the pointer
 	m_palette_select = nullptr;
 	m_tileset_select = nullptr;
 	m_zoomslider = nullptr;
+	EditorFrame::ClearMenu(menu);
 }
 
 void Map2DEditorFrame::UpdateUI() const

--- a/src/user_interface/blockset/src/BlocksetEditorFrame.cpp
+++ b/src/user_interface/blockset/src/BlocksetEditorFrame.cpp
@@ -228,10 +228,10 @@ void BlocksetEditorFrame::OnMenuClick(wxMenuEvent& evt)
 
 void BlocksetEditorFrame::ClearMenu(wxMenuBar& menu) const
 {
-	EditorFrame::ClearMenu(menu);
 	// The toolbar destructor deletes these, but doesn't clear the pointer
 	m_palette_select = nullptr;
 	m_zoomslider = nullptr;
+	EditorFrame::ClearMenu(menu);
 }
 
 void BlocksetEditorFrame::ExportBin(const std::string& filename) const

--- a/src/user_interface/main/src/MainFrame.cpp
+++ b/src/user_interface/main/src/MainFrame.cpp
@@ -108,7 +108,7 @@ void MainFrame::OnAbout(wxCommandEvent& event)
     icn.CopyFromBitmap(m_imgs32->GetImage("msword"));
     info.SetIcon(icn);
     info.SetName(_("Landstalker Editor"));
-    info.SetVersion(_("0.3.3"));
+    info.SetVersion(_("0.3.4"));
     info.SetCopyright(_("Copyright 2024 All Rights Reserved."));
     info.SetWebSite(_("https://github.com/lordmir/landstalker_editor"), _("GitHub"));
     info.AddDeveloper(_("LordMir <hase@redfern.xyz>"));

--- a/src/user_interface/sprites/src/SpriteEditorFrame.cpp
+++ b/src/user_interface/sprites/src/SpriteEditorFrame.cpp
@@ -283,11 +283,14 @@ void SpriteEditorFrame::RedrawTiles(int index) const
 
 void SpriteEditorFrame::Update()
 {
-	m_subspritectrl->SetSubsprites(m_sprite->GetData()->GetSubSprites());
-	m_framectrl->SetSprite(m_sprite->GetSprite());
-	m_animctrl->SetSprite(m_sprite->GetSprite());
-	m_animframectrl->SetAnimation(m_sprite->GetSprite(), m_anim);
-	Redraw();
+	if (m_sprite != nullptr)
+	{
+		m_subspritectrl->SetSubsprites(m_sprite->GetData()->GetSubSprites());
+		m_framectrl->SetSprite(m_sprite->GetSprite());
+		m_animctrl->SetSprite(m_sprite->GetSprite());
+		m_animframectrl->SetAnimation(m_sprite->GetSprite(), m_anim);
+		Redraw();
+	}
 	UpdateUI();
 	FireEvent(EVT_PROPERTIES_UPDATE);
 	FireEvent(EVT_STATUSBAR_UPDATE);
@@ -367,9 +370,10 @@ void SpriteEditorFrame::InitMenu(wxMenuBar& menu, ImageList& ilist) const
 
 void SpriteEditorFrame::ClearMenu(wxMenuBar& menu) const
 {
-	EditorFrame::ClearMenu(menu);
+	// The toolbar destructor deletes these, but doesn't clear the pointer
 	m_zoomslider = nullptr;
 	m_speedslider = nullptr;
+	EditorFrame::ClearMenu(menu);
 }
 
 void SpriteEditorFrame::OnMenuClick(wxMenuEvent& evt)

--- a/src/user_interface/tileset/src/TilesetEditorFrame.cpp
+++ b/src/user_interface/tileset/src/TilesetEditorFrame.cpp
@@ -842,8 +842,9 @@ void TilesetEditorFrame::OnMenuClick(wxMenuEvent& evt)
 
 void TilesetEditorFrame::ClearMenu(wxMenuBar& menu) const
 {
-	EditorFrame::ClearMenu(menu);
+	// The toolbar destructor deletes these, but doesn't clear the pointer
 	m_zoomslider = nullptr;
+	EditorFrame::ClearMenu(menu);
 }
 
 void TilesetEditorFrame::SetGameData(std::shared_ptr<GameData> gd)


### PR DESCRIPTION
Issue was a result of a null pointer dereference, as well as a potential race condition in the menu code which allowed for a deleted object to be dereferenced before its pointer had been cleared.