### PR TITLE
export blockset flags as tmx tile properties

### DIFF
--- a/src/landstalker/3d_maps/include/MapToTmx.h
+++ b/src/landstalker/3d_maps/include/MapToTmx.h
@@ -8,7 +8,7 @@ class MapToTmx
 {
 public:
 	static bool ImportFromTmx(const std::string& fname, Tilemap3D& map);
-	static bool ExportToTmx(const std::string& fname, const Tilemap3D& map, const std::string& blockset_filename);
+	static bool ExportToTmx(const std::string& fname, const Tilemap3D& map, const std::string& blockset_filename, const std::shared_ptr<Blockset> blockset);
 };
 
 #endif // _MAP_TO_TMX_H_

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -432,7 +432,7 @@ bool RoomViewerFrame::ExportTmx(const std::string& tmx_path, const std::string& 
 		}
 	}
 	buf.WritePNG(bs_path, { palette }, true);
-	return MapToTmx::ExportToTmx(tmx_path, *m_g->GetRoomData()->GetMapForRoom(roomnum)->GetData(), bs_path);
+	return MapToTmx::ExportToTmx(tmx_path, *m_g->GetRoomData()->GetMapForRoom(roomnum)->GetData(), bs_path, blocksets);
 }
 
 bool RoomViewerFrame::ExportAllTmx(const std::string& dir)


### PR DESCRIPTION
When export map as tiled TMX, also export tile attributes from the blockset as properties
each tiled tile (blockset in landstalker) has 3 properties for each of the 4 blockset tile : 

0hasPriority
0isHFlipped
0isVFlipped
1hasPriority
1isHFlipped
1isVFlipped
2hasPriority
2isHFlipped
2isVFlipped
3hasPriority
3isHFlipped
3isVFlipped

0 is top left tile, 1 is top right, 2 is bottom left and 3 is bottom right

these flags are needed for my wip [python port of landstalker  ](https://github.com/odrevet/landstalker-py) and may be useful to be displayed in tiled, but there are a few drawbacks : 

* the export of all tmx maps take a lot more time
* tmx file are larger

if you think the flags export is a good addition to the editor some adaptation may be needed, maybe export the flags as hex values (like in export blockset as csv) and moving the properties to a separated tsx file ? 
