### PR TITLE
Export room tmx

### DIFF
--- a/VC2019/landstalker_edit.vcxproj
+++ b/VC2019/landstalker_edit.vcxproj
@@ -17,6 +17,7 @@
     <ClCompile Include="..\src\landstalker\3d_maps\src\BlockmapIsometric.cpp" />
     <ClCompile Include="..\src\landstalker\3d_maps\src\Doors.cpp" />
     <ClCompile Include="..\src\landstalker\3d_maps\src\MapToTmx.cpp" />
+    <ClCompile Include="..\src\landstalker\3d_maps\src\RoomToTmx.cpp" />
     <ClCompile Include="..\src\landstalker\3d_maps\src\Tilemap3DCmp.cpp" />
     <ClCompile Include="..\src\landstalker\3d_maps\src\TileSwaps.cpp" />
     <ClCompile Include="..\src\landstalker\behaviours\src\Behaviours.cpp" />
@@ -118,6 +119,7 @@
     <ClInclude Include="..\src\landstalker\3d_maps\include\BlockmapIsometric.h" />
     <ClInclude Include="..\src\landstalker\3d_maps\include\Doors.h" />
     <ClInclude Include="..\src\landstalker\3d_maps\include\MapToTmx.h" />
+    <ClInclude Include="..\src\landstalker\3d_maps\include\RoomToTmx.h" />
     <ClInclude Include="..\src\landstalker\3d_maps\include\Tilemap3DCmp.h" />
     <ClInclude Include="..\src\landstalker\3d_maps\include\TileSwaps.h" />
     <ClInclude Include="..\src\landstalker\behaviours\include\Behaviours.h" />

--- a/src/landstalker/3d_maps/include/MapToTmx.h
+++ b/src/landstalker/3d_maps/include/MapToTmx.h
@@ -2,12 +2,14 @@
 #define _MAP_TO_TMX_H_
 
 #include <string>
+#include <wx/xml/xml.h>
 #include <landstalker/main/include/DataTypes.h>
 
 class MapToTmx
 {
 public:
 	static bool ImportFromTmx(const std::string& fname, Tilemap3D& map);
+	static wxXmlDocument GenerateXmlDocument(const std::string& fname, const Tilemap3D& map, const std::string& blockset_filename);
 	static bool ExportToTmx(const std::string& fname, const Tilemap3D& map, const std::string& blockset_filename);
 };
 

--- a/src/landstalker/3d_maps/include/RoomToTmx.h
+++ b/src/landstalker/3d_maps/include/RoomToTmx.h
@@ -3,12 +3,12 @@
 
 #include <string>
 #include <landstalker/main/include/DataTypes.h>
-#include <landstalker/main/include/RoomData.h>
+#include <landstalker/main/include/GameData.h>
 
 class RoomToTmx
 {
 public:
-	static bool ExportToTmx(const std::string& fname, int roomnum, std::shared_ptr<RoomData> roomData, const std::string& blockset_filename);
+	static bool ExportToTmx(const std::string& fname, int roomnum, std::shared_ptr<GameData> gameData, const std::string& blockset_filename);
 };
 
 #endif // _ROOM_TO_TMX_H_

--- a/src/landstalker/3d_maps/include/RoomToTmx.h
+++ b/src/landstalker/3d_maps/include/RoomToTmx.h
@@ -1,0 +1,14 @@
+#ifndef _ROOM_TO_TMX_H_
+#define _ROOM_TO_TMX_H_
+
+#include <string>
+#include <landstalker/main/include/DataTypes.h>
+#include <landstalker/main/include/RoomData.h>
+
+class RoomToTmx
+{
+public:
+	static bool ExportToTmx(const std::string& fname, int roomnum, std::shared_ptr<RoomData> roomData, const std::string& blockset_filename);
+};
+
+#endif // _ROOM_TO_TMX_H_

--- a/src/landstalker/3d_maps/src/MapToTmx.cpp
+++ b/src/landstalker/3d_maps/src/MapToTmx.cpp
@@ -2,7 +2,6 @@
 #include <sstream>
 #include <iomanip>
 #include <wx/filename.h>
-#include <wx/xml/xml.h>
 
 std::string GetData(const Tilemap3D& map, Tilemap3D::Layer layer)
 {
@@ -91,7 +90,7 @@ bool MapToTmx::ImportFromTmx(const std::string& fname, Tilemap3D& map)
 	return false;
 }
 
-bool MapToTmx::ExportToTmx(const std::string& fname, const Tilemap3D& map, const std::string& blockset_filename)
+wxXmlDocument MapToTmx::GenerateXmlDocument(const std::string& fname, const Tilemap3D& map, const std::string& blockset_filename)
 {
 	wxXmlDocument tmx;
 	wxFileName fn(fname);
@@ -153,5 +152,11 @@ bool MapToTmx::ExportToTmx(const std::string& fname, const Tilemap3D& map, const
 	tmx.GetRoot()->AddChild(bg_layer);
 	tmx.GetRoot()->AddChild(fg_layer);
 
+	return tmx;
+}
+
+bool MapToTmx::ExportToTmx(const std::string& fname, const Tilemap3D& map, const std::string& blockset_filename)
+{
+	wxXmlDocument tmx = MapToTmx::GenerateXmlDocument(fname, map, blockset_filename);
 	return tmx.Save(fname);
 }

--- a/src/landstalker/3d_maps/src/RoomToTmx.cpp
+++ b/src/landstalker/3d_maps/src/RoomToTmx.cpp
@@ -291,7 +291,7 @@ for (const auto& entity : entities) {
 
     auto speed_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
     speed_property->AddAttribute("name", "Speed");
-	speed_property->AddAttribute("type", "bool");
+	speed_property->AddAttribute("type", "int");
     speed_property->AddAttribute("value", std::to_string(entity.GetSpeed()));
     properties->AddChild(speed_property);
 

--- a/src/landstalker/3d_maps/src/RoomToTmx.cpp
+++ b/src/landstalker/3d_maps/src/RoomToTmx.cpp
@@ -189,48 +189,126 @@ bool RoomToTmx::ExportToTmx(const std::string& fname, int roomnum, std::shared_p
 	entities_objectgroup->AddAttribute("id", "4");
 	entities_objectgroup->AddAttribute("name", "Entities");
 
-	int entity_id = 1;
-	std::vector<Entity> entities = gameData->GetSpriteData()->GetRoomEntities(roomnum);
+int entity_id = 1;
+std::vector<Entity> entities = gameData->GetSpriteData()->GetRoomEntities(roomnum);
 
-	for (const auto& entity : entities) {
-		auto entity_object = new wxXmlNode(wxXML_ELEMENT_NODE, "object");
-		entity_object->AddAttribute("id", std::to_string(entity_id));
-		entity_object->AddAttribute("x", std::to_string(entity.GetX()));
-		entity_object->AddAttribute("y", std::to_string(entity.GetY()));
-		entity_object->AddAttribute("visible", entity.IsVisible() ? "1" : "0");
-		entity_object->AddAttribute("name", entity.GetTypeName());
-		entities_objectgroup->AddChild(entity_object);
+for (const auto& entity : entities) {
+    auto entity_object = new wxXmlNode(wxXML_ELEMENT_NODE, "object");
+    entity_object->AddAttribute("id", std::to_string(entity_id));
+    entity_object->AddAttribute("visible", "0");
+    entity_object->AddAttribute("name", entity.GetTypeName());
+	entity_object->AddAttribute("class", entity.GetTypeName());
+    entities_objectgroup->AddChild(entity_object);
 
-		// Entity properties
-		auto properties = new wxXmlNode(wxXML_ELEMENT_NODE, "properties");
+    // Entity properties
+    auto properties = new wxXmlNode(wxXML_ELEMENT_NODE, "properties");
 
-		auto add_property = [&properties](const std::string& name, const std::string& value) {
-			auto property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
-			property->AddAttribute("name", name);
-			property->AddAttribute("value", value);
-			properties->AddChild(property);
-		};
+    auto type_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    type_property->AddAttribute("name", "Type");
+    type_property->AddAttribute("value", std::to_string(entity.GetType()));
+    properties->AddChild(type_property);
 
-		add_property("Type", std::to_string(entity.GetType()));
-		add_property("Palette", std::to_string(entity.GetPalette()));
-		add_property("Behaviour", std::to_string(entity.GetBehaviour()));
-		add_property("Dialogue", std::to_string(entity.GetDialogue()));
-		add_property("Hostile", entity.IsHostile() ? "true" : "false");
-		add_property("NoRotate", entity.NoRotate() ? "true" : "false");
-		add_property("NoPickup", entity.NoPickup() ? "true" : "false");
-		add_property("HasDialogue", entity.HasDialogue() ? "true" : "false");
-		add_property("Visible", entity.IsVisible() ? "true" : "false");
-		add_property("Solid", entity.IsSolid() ? "true" : "false");
-		add_property("Gravity", entity.HasGravity() ? "true" : "false");
-		add_property("Friction", entity.HasFriction() ? "true" : "false");
-		add_property("Speed", std::to_string(entity.GetSpeed()));
-		add_property("Orientation", entity.GetOrientationName());
-		add_property("TileSource", std::to_string(entity.GetCopySource()));
+    auto x_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    x_property->AddAttribute("name", "X");
+	x_property->AddAttribute("type", "float");
+    x_property->AddAttribute("value", std::to_string(entity.GetXDbl()));
+    properties->AddChild(x_property);
 
-		entity_object->AddChild(properties);
-		
-		entity_id++;
-	}
+    auto y_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    y_property->AddAttribute("name", "Y");
+	y_property->AddAttribute("type", "float");
+    y_property->AddAttribute("value", std::to_string(entity.GetYDbl()));
+    properties->AddChild(y_property);
+
+    auto z_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    z_property->AddAttribute("name", "Z");
+	z_property->AddAttribute("type", "float");
+    z_property->AddAttribute("value", std::to_string(entity.GetZDbl()));
+    properties->AddChild(z_property);
+
+    auto palette_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    palette_property->AddAttribute("name", "Palette");
+    palette_property->AddAttribute("value", std::to_string(entity.GetPalette()));
+    properties->AddChild(palette_property);
+
+    auto behaviour_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    behaviour_property->AddAttribute("name", "Behaviour");
+    behaviour_property->AddAttribute("value", std::to_string(entity.GetBehaviour()));
+    properties->AddChild(behaviour_property);
+
+    auto dialogue_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    dialogue_property->AddAttribute("name", "Dialogue");
+    dialogue_property->AddAttribute("value", std::to_string(entity.GetDialogue()));
+    properties->AddChild(dialogue_property);
+
+    auto hostile_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    hostile_property->AddAttribute("name", "Hostile");
+	hostile_property->AddAttribute("type", "bool");
+    hostile_property->AddAttribute("value", entity.IsHostile() ? "true" : "false");
+    properties->AddChild(hostile_property);
+
+    auto no_rotate_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    no_rotate_property->AddAttribute("name", "NoRotate");
+	no_rotate_property->AddAttribute("type", "bool");
+    no_rotate_property->AddAttribute("value", entity.NoRotate() ? "true" : "false");
+    properties->AddChild(no_rotate_property);
+
+    auto no_pickup_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    no_pickup_property->AddAttribute("name", "NoPickup");
+	no_pickup_property->AddAttribute("type", "bool");
+    no_pickup_property->AddAttribute("value", entity.NoPickup() ? "true" : "false");
+    properties->AddChild(no_pickup_property);
+
+    auto has_dialogue_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    has_dialogue_property->AddAttribute("name", "HasDialogue");
+	has_dialogue_property->AddAttribute("type", "bool");
+    has_dialogue_property->AddAttribute("value", entity.HasDialogue() ? "true" : "false");
+    properties->AddChild(has_dialogue_property);
+
+    auto visible_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    visible_property->AddAttribute("name", "Visible");
+	visible_property->AddAttribute("type", "bool");
+    visible_property->AddAttribute("value", entity.IsVisible() ? "true" : "false");
+    properties->AddChild(visible_property);
+
+    auto solid_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    solid_property->AddAttribute("name", "Solid");
+	solid_property->AddAttribute("type", "bool");
+    solid_property->AddAttribute("value", entity.IsSolid() ? "true" : "false");
+    properties->AddChild(solid_property);
+
+    auto gravity_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    gravity_property->AddAttribute("name", "Gravity");
+	gravity_property->AddAttribute("type", "bool");
+    gravity_property->AddAttribute("value", entity.HasGravity() ? "true" : "false");
+    properties->AddChild(gravity_property);
+
+    auto friction_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    friction_property->AddAttribute("name", "Friction");
+	friction_property->AddAttribute("type", "bool");
+    friction_property->AddAttribute("value", entity.HasFriction() ? "true" : "false");
+    properties->AddChild(friction_property);
+
+    auto speed_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    speed_property->AddAttribute("name", "Speed");
+	speed_property->AddAttribute("type", "bool");
+    speed_property->AddAttribute("value", std::to_string(entity.GetSpeed()));
+    properties->AddChild(speed_property);
+
+    auto orientation_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    orientation_property->AddAttribute("name", "Orientation");
+    orientation_property->AddAttribute("value", entity.GetOrientationName());
+    properties->AddChild(orientation_property);
+
+    auto tile_source_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+    tile_source_property->AddAttribute("name", "TileSource");
+    tile_source_property->AddAttribute("value", std::to_string(entity.GetCopySource()));
+    properties->AddChild(tile_source_property);
+
+    entity_object->AddChild(properties);
+    
+    entity_id++;
+}
 
 	tmx.GetRoot()->AddChild(entities_objectgroup);
 

--- a/src/landstalker/3d_maps/src/RoomToTmx.cpp
+++ b/src/landstalker/3d_maps/src/RoomToTmx.cpp
@@ -1,0 +1,12 @@
+#include <landstalker/3d_maps/include/RoomToTmx.h>
+#include <landstalker/3d_maps/include/MapToTmx.h>
+#include <sstream>
+#include <iomanip>
+#include <wx/filename.h>
+#include <wx/xml/xml.h>
+
+bool RoomToTmx::ExportToTmx(const std::string& fname, int roomnum, std::shared_ptr<RoomData> roomData, const std::string& blockset_filename)
+{
+	wxXmlDocument tmx = MapToTmx::GenerateXmlDocument(fname, *(roomData->GetMapForRoom(roomnum)->GetData()), blockset_filename);
+	return tmx.Save(fname);
+}

--- a/src/landstalker/3d_maps/src/RoomToTmx.cpp
+++ b/src/landstalker/3d_maps/src/RoomToTmx.cpp
@@ -161,7 +161,7 @@ bool RoomToTmx::ExportToTmx(const std::string& fname, int roomnum, std::shared_p
 		properties->AddChild(y2_property);
 		
 		auto type_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
-		type_property->AddAttribute("name", "type");
+		type_property->AddAttribute("name", "warpType");
 
 		// Convert the warp type to a string
 		std::string warp_type_str;

--- a/src/landstalker/3d_maps/src/RoomToTmx.cpp
+++ b/src/landstalker/3d_maps/src/RoomToTmx.cpp
@@ -1,5 +1,7 @@
 #include <landstalker/3d_maps/include/RoomToTmx.h>
 #include <landstalker/3d_maps/include/MapToTmx.h>
+#include <landstalker/rooms/include/Room.h>
+#include <landstalker/rooms/include/WarpList.h>
 #include <sstream>
 #include <iomanip>
 #include <wx/filename.h>
@@ -8,5 +10,176 @@
 bool RoomToTmx::ExportToTmx(const std::string& fname, int roomnum, std::shared_ptr<RoomData> roomData, const std::string& blockset_filename)
 {
 	wxXmlDocument tmx = MapToTmx::GenerateXmlDocument(fname, *(roomData->GetMapForRoom(roomnum)->GetData()), blockset_filename);
+
+	// Properties
+	auto room = roomData->GetRoom(roomnum);
+	auto properties = new wxXmlNode(wxXML_ELEMENT_NODE, "properties");
+
+	// Room Properties
+	auto name_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	name_property->AddAttribute("name", "RoomName");
+	name_property->AddAttribute("value", room->name);
+	properties->AddChild(name_property);
+
+	auto room_number_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	room_number_property->AddAttribute("name", "RoomNumber");
+	room_number_property->AddAttribute("value", std::to_string(roomnum));
+	properties->AddChild(room_number_property);
+
+	auto tileset_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	tileset_property->AddAttribute("name", "RoomTileset");
+	tileset_property->AddAttribute("value", std::to_string(room->tileset));
+	properties->AddChild(tileset_property);
+
+	auto palette_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	palette_property->AddAttribute("name", "RoomPalette");
+	palette_property->AddAttribute("value", std::to_string(room->room_palette));
+	properties->AddChild(palette_property);
+
+	auto pri_blockset_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	pri_blockset_property->AddAttribute("name", "RoomPrimaryBlockset");
+	pri_blockset_property->AddAttribute("value", std::to_string(room->pri_blockset));
+	properties->AddChild(pri_blockset_property);
+
+	auto sec_blockset_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	sec_blockset_property->AddAttribute("name", "RoomSecondaryBlockset");
+	sec_blockset_property->AddAttribute("value", std::to_string(room->sec_blockset));
+	properties->AddChild(sec_blockset_property);
+
+	auto bgm_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	bgm_property->AddAttribute("name", "RoomBGM");
+	bgm_property->AddAttribute("value", std::to_string(room->bgm));
+	properties->AddChild(bgm_property);
+
+	auto map_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	map_property->AddAttribute("name", "RoomMap");
+	map_property->AddAttribute("value", room->map);
+	properties->AddChild(map_property);
+
+	auto unknown_param1_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	unknown_param1_property->AddAttribute("name", "RoomUnknownParam1");
+	unknown_param1_property->AddAttribute("value", std::to_string(room->unknown_param1));
+	properties->AddChild(unknown_param1_property);
+
+	auto unknown_param2_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	unknown_param2_property->AddAttribute("name", "RoomUnknownParam2");
+	unknown_param2_property->AddAttribute("value", std::to_string(room->unknown_param2));
+	properties->AddChild(unknown_param2_property);
+
+	auto z_begin_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	z_begin_property->AddAttribute("name", "RoomZBegin");
+	z_begin_property->AddAttribute("value", std::to_string(room->room_z_begin));
+	properties->AddChild(z_begin_property);
+
+	auto z_end_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	z_end_property->AddAttribute("name", "RoomZEnd");
+	z_end_property->AddAttribute("value", std::to_string(room->room_z_end));
+	properties->AddChild(z_end_property);
+
+	// Warps Properties
+	auto fall_destination_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	fall_destination_property->AddAttribute("name", "WarpFallDestination");
+	fall_destination_property->AddAttribute("type", "int");
+	fall_destination_property->AddAttribute("value", std::to_string(roomData->GetFallDestination(roomnum)));
+	properties->AddChild(fall_destination_property);
+
+	auto climb_destination_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	climb_destination_property->AddAttribute("name", "WarpClimbDestination");
+	climb_destination_property->AddAttribute("type", "int");
+	climb_destination_property->AddAttribute("value", std::to_string(roomData->GetClimbDestination(roomnum)));
+	properties->AddChild(climb_destination_property);
+
+	// Flags Properties
+	auto lantern_room_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	lantern_room_property->AddAttribute("name", "FlagHasLantern");
+	lantern_room_property->AddAttribute("type", "bool");
+	lantern_room_property->AddAttribute("value", roomData->HasLanternFlag(roomnum) ? "true" : "false");
+	properties->AddChild(lantern_room_property);
+
+	// Misc Properties
+	auto shop_room_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	shop_room_property->AddAttribute("name", "FlagIsShopChurchInn");
+	shop_room_property->AddAttribute("type", "bool");
+	shop_room_property->AddAttribute("value", roomData->IsShop(roomnum) ? "true" : "false");
+	properties->AddChild(shop_room_property);
+
+	auto lifestock_for_sale_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	lifestock_for_sale_property->AddAttribute("name", "MiscLifestockForSale");
+	lifestock_for_sale_property->AddAttribute("type", "bool");
+	lifestock_for_sale_property->AddAttribute("value", roomData->HasLifestockSaleFlag(roomnum) ? "true" : "false");
+	properties->AddChild(lifestock_for_sale_property);
+
+	auto lifestock_sale_flags_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+	lifestock_sale_flags_property->AddAttribute("name", "MiscLifestockSaleFlag");
+	lifestock_sale_flags_property->AddAttribute("type", "int");
+	lifestock_sale_flags_property->AddAttribute("value", std::to_string(roomData->GetLifestockSaleFlag(roomnum)));
+	properties->AddChild(lifestock_sale_flags_property);
+
+	tmx.GetRoot()->AddChild(properties);
+
+
+	// Warps object
+	auto warps_objectgroup = new wxXmlNode(wxXML_ELEMENT_NODE, "objectgroup");
+	warps_objectgroup->AddAttribute("id", "3");
+	warps_objectgroup->AddAttribute("name", "Warps");
+
+	int warp_id = 1;
+    std::vector<WarpList::Warp> warps = roomData->GetWarpsForRoom(roomnum);
+	for (const auto& warp : warps) {
+		auto warp_object = new wxXmlNode(wxXML_ELEMENT_NODE, "object");
+		warp_object->AddAttribute("id", std::to_string(warp_id));
+		warp_object->AddAttribute("visible", "0");
+		warp_object->AddAttribute("name", "Warp");
+		warp_object->AddAttribute("x", std::to_string(warp.x1));
+		warp_object->AddAttribute("y", std::to_string(warp.y1));
+		warp_object->AddAttribute("width", std::to_string(warp.x_size));
+		warp_object->AddAttribute("height", std::to_string(warp.y_size));
+		
+		// Adding warp properties
+		auto properties = new wxXmlNode(wxXML_ELEMENT_NODE, "properties");
+		
+		auto room1_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+		room1_property->AddAttribute("name", "room1");
+		room1_property->AddAttribute("value", std::to_string(warp.room1));
+		properties->AddChild(room1_property);
+		
+		auto room2_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+		room2_property->AddAttribute("name", "room2");
+		room2_property->AddAttribute("value", std::to_string(warp.room2));
+		properties->AddChild(room2_property);
+		
+		auto x2_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+		x2_property->AddAttribute("name", "x2");
+		x2_property->AddAttribute("value", std::to_string(warp.x2));
+		properties->AddChild(x2_property);
+		
+		auto y2_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+		y2_property->AddAttribute("name", "y2");
+		y2_property->AddAttribute("value", std::to_string(warp.y2));
+		properties->AddChild(y2_property);
+		
+		auto type_property = new wxXmlNode(wxXML_ELEMENT_NODE, "property");
+		type_property->AddAttribute("name", "type");
+
+		// Convert the warp type to a string
+		std::string warp_type_str;
+		switch (warp.type) {
+			case WarpList::Warp::Type::NORMAL:   warp_type_str = "NORMAL"; break;
+			case WarpList::Warp::Type::STAIR_SE: warp_type_str = "STAIR_SE"; break;
+			case WarpList::Warp::Type::STAIR_SW: warp_type_str = "STAIR_SW"; break;
+			default:                   warp_type_str = "UNKNOWN"; break;
+		}
+
+		type_property->AddAttribute("value", warp_type_str);
+		properties->AddChild(type_property);
+		
+		warp_object->AddChild(properties);
+		warp_id++;
+		warps_objectgroup->AddChild(warp_object);
+	}
+
+
+	tmx.GetRoot()->AddChild(warps_objectgroup);
+
 	return tmx.Save(fname);
 }

--- a/src/user_interface/rooms/include/RoomViewerFrame.h
+++ b/src/user_interface/rooms/include/RoomViewerFrame.h
@@ -50,6 +50,7 @@ public:
 	bool ExportTmx(const std::string& tmx_path, const std::string& bs_path, uint16_t roomnum);
 	bool ExportAllTmx(const std::string& dir);
 	bool ExportPng(const std::string& path);
+	bool ExportRoomTmx(const std::string& tmx_path, const std::string& bs_path, uint16_t roomnum);
 	bool ImportBin(const std::string& path);
 	bool ImportCsv(const std::array<std::string, 3>& paths);
 	bool ImportTmx(const std::string& paths, uint16_t roomnum);
@@ -87,6 +88,7 @@ private:
 	void OnExportAllCsv();
 	void OnExportTmx();
 	void OnExportAllTmx();
+	void OnExportRoomTmx();
 	void OnExportPng();
 	void OnImportBin();
 	void OnImportCsv();

--- a/src/user_interface/rooms/include/RoomViewerFrame.h
+++ b/src/user_interface/rooms/include/RoomViewerFrame.h
@@ -50,6 +50,7 @@ public:
 	bool ExportTmx(const std::string& tmx_path, const std::string& bs_path, uint16_t roomnum);
 	bool ExportAllTmx(const std::string& dir);
 	bool ExportPng(const std::string& path);
+	bool ExportAllRoomsTmx(const std::string& dir);
 	bool ExportRoomTmx(const std::string& tmx_path, const std::string& bs_path, uint16_t roomnum);
 	bool ImportBin(const std::string& path);
 	bool ImportCsv(const std::array<std::string, 3>& paths);
@@ -89,6 +90,7 @@ private:
 	void OnExportTmx();
 	void OnExportAllTmx();
 	void OnExportRoomTmx();
+	void OnExportAllRoomsTmx();
 	void OnExportPng();
 	void OnImportBin();
 	void OnImportCsv();

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -10,6 +10,7 @@
 #include <user_interface/rooms/include/RoomErrorDialog.h>
 #include <user_interface/rooms/include/TileSwapDialog.h>
 #include <landstalker/3d_maps/include/MapToTmx.h>
+#include <landstalker/3d_maps/include/RoomToTmx.h>
 #include <user_interface/rooms/include/RoomViewerCtrl.h>
 
 enum MENU_IDS
@@ -20,6 +21,7 @@ enum MENU_IDS
 	ID_FILE_EXPORT_TMX,
 	ID_FILE_EXPORT_ALL_TMX,
 	ID_FILE_EXPORT_PNG,
+	ID_FILE_EXPORT_ROOM_TMX,
 	ID_FILE_SEP1,
 	ID_FILE_IMPORT_BIN,
 	ID_FILE_IMPORT_CSV,
@@ -454,6 +456,41 @@ bool RoomViewerFrame::ExportAllTmx(const std::string& dir)
 	}
 	wxSetWorkingDirectory(curdir);
 	return true;
+}
+
+bool RoomViewerFrame::ExportRoomTmx(const std::string& tmx_path, const std::string& bs_path, uint16_t roomnum)
+{
+	auto map = m_g->GetRoomData()->GetMapForRoom(roomnum)->GetData();
+	auto blocksets = m_g->GetRoomData()->GetCombinedBlocksetForRoom(roomnum);
+	auto palette = std::vector<std::shared_ptr<Palette>>{ m_g->GetRoomData()->GetPaletteForRoom(roomnum)->GetData() };
+	auto tileset = m_g->GetRoomData()->GetTilesetForRoom(roomnum)->GetData();
+
+	const int width = 16;
+	const int height = 64;
+	int blockwidth = MapBlock::GetBlockWidth() * tileset->GetTileWidth();
+	int blockheight = MapBlock::GetBlockHeight() * tileset->GetTileHeight();
+	int pixelwidth = blockwidth * width;
+	int pixelheight = blockheight * height;
+	ImageBuffer buf(pixelwidth, pixelheight);
+	std::size_t i = 0;
+	for (int y = 0; y < pixelheight; y += blockheight)
+	{
+		for (int x = 0; x < pixelwidth; x += blockwidth, ++i)
+		{
+			if (i < blocksets->size())
+			{
+				buf.InsertBlock(x, y, 0, blocksets->at(i), *tileset);
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+	buf.WritePNG(bs_path, { palette }, true);
+
+	std::shared_ptr<RoomData> roomData = m_g->GetRoomData();
+	return RoomToTmx::ExportToTmx(tmx_path, roomnum, roomData, bs_path);
 }
 
 bool RoomViewerFrame::ExportPng(const std::string& path)
@@ -1271,10 +1308,11 @@ void RoomViewerFrame::InitMenu(wxMenuBar& menu, ImageList& ilist) const
 	AddMenuItem(fileMenu, 3, ID_FILE_EXPORT_TMX, "Export Map as Tiled TMX...");
 	AddMenuItem(fileMenu, 4, ID_FILE_EXPORT_ALL_TMX, "Export All Maps as Tiled TMX...");
 	AddMenuItem(fileMenu, 5, ID_FILE_EXPORT_PNG, "Export Map as PNG...");
-	AddMenuItem(fileMenu, 6, ID_FILE_SEP1, "", wxITEM_SEPARATOR);
-	AddMenuItem(fileMenu, 7, ID_FILE_IMPORT_BIN, "Import Map from Binary...");
-	AddMenuItem(fileMenu, 8, ID_FILE_IMPORT_CSV, "Import Map from CSV...");
-	AddMenuItem(fileMenu, 9, ID_FILE_IMPORT_ALL_TMX, "Import All Maps from Tiled TMX...");
+	AddMenuItem(fileMenu, 7, ID_FILE_EXPORT_ROOM_TMX, "Export Room as Tiled TMX...");
+	AddMenuItem(fileMenu, 8, ID_FILE_SEP1, "", wxITEM_SEPARATOR);
+	AddMenuItem(fileMenu, 9, ID_FILE_IMPORT_BIN, "Import Map from Binary...");
+	AddMenuItem(fileMenu, 10, ID_FILE_IMPORT_CSV, "Import Map from CSV...");
+	AddMenuItem(fileMenu, 11, ID_FILE_IMPORT_ALL_TMX, "Import All Maps from Tiled TMX...");
 
 	auto& editMenu = AddMenu(menu, 1, ID_EDIT, "Edit");
 	AddMenuItem(editMenu, 0, ID_EDIT_ENTITY_PROPERTIES, "Selection Properties...");
@@ -1438,6 +1476,9 @@ void RoomViewerFrame::OnMenuClick(wxMenuEvent& evt)
 			break;
 		case ID_FILE_EXPORT_PNG:
 			OnExportPng();
+			break;
+		case ID_FILE_EXPORT_ROOM_TMX:
+			OnExportRoomTmx();
 			break;
 		case ID_FILE_IMPORT_BIN:
 			OnImportBin();
@@ -1753,6 +1794,23 @@ void RoomViewerFrame::OnExportAllTmx()
 	if (dd.ShowModal() != wxID_CANCEL)
 	{
 		ExportAllTmx(dd.GetPath().ToStdString());
+	}
+}
+
+void RoomViewerFrame::OnExportRoomTmx()
+{
+	auto rd = m_g->GetRoomData()->GetRoom(m_roomnum);
+	wxString default_file = wxString::Format("Room%03d.tmx", m_roomnum);
+	wxFileDialog fd(this, _("Export Room As TMX"), "", default_file, "Tiled TMX Tilemap (*.tmx)|*.tmx|All Files (*.*)|*.*", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+	if (fd.ShowModal() != wxID_CANCEL)
+	{
+		wxString tmx_file = fd.GetPath();
+		default_file = StrPrintf("BT%02d_%01d%01d_p%02d.png", rd->tileset + 1, rd->pri_blockset, rd->sec_blockset + 1, rd->room_palette + 1);
+		wxFileDialog bfd(this, _("Export Blockset As PNG"), "", default_file, "PNG Image (*.png)|*.png|All Files (*.*)|*.*", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+		if (bfd.ShowModal() != wxID_CANCEL)
+		{
+			ExportRoomTmx(tmx_file.ToStdString(), bfd.GetPath().ToStdString(), m_roomnum);
+		}
 	}
 }
 

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -489,8 +489,7 @@ bool RoomViewerFrame::ExportRoomTmx(const std::string& tmx_path, const std::stri
 	}
 	buf.WritePNG(bs_path, { palette }, true);
 
-	std::shared_ptr<RoomData> roomData = m_g->GetRoomData();
-	return RoomToTmx::ExportToTmx(tmx_path, roomnum, roomData, bs_path);
+	return RoomToTmx::ExportToTmx(tmx_path, roomnum, m_g, bs_path);
 }
 
 bool RoomViewerFrame::ExportPng(const std::string& path)


### PR DESCRIPTION
Export rooms as tiled TMX. The room contains the map data, most of the room properties as tiled properties and the entities and warps as tiled objects. 
The entites and warps "visible" property is set to 0 as the x and y coords in landstalker needs additional computation like offsets and heightmap and will not be correctly placed in tiled without some scripting. 