### PR TITLE
Fix workdir

### DIFF
--- a/src/user_interface/misc/src/AssemblyBuilderDialog.cpp
+++ b/src/user_interface/misc/src/AssemblyBuilderDialog.cpp
@@ -264,7 +264,7 @@ bool AssemblyBuilderDialog::Assemble(bool post_save)
         Log("Unable to write to directory \"" + m_dir + "\".\n", *wxRED);
         return false;
     }
-    wxSetWorkingDirectory(m_dir);
+
     if (dir.HasFiles() || dir.HasSubDirs())
     {
         m_step = Step::BUILD;
@@ -306,7 +306,7 @@ bool AssemblyBuilderDialog::Build(bool post_save)
     {
         return true;
     }
-    wxSetWorkingDirectory(m_dir);
+
     if (dir.HasFiles(baseasm) && dir.HasSubDirs())
     {
         m_step = Step::BUILD;
@@ -397,7 +397,8 @@ bool AssemblyBuilderDialog::DoClone()
         return false;
     }
 
-    if (wxExecute(cmd, wxEXEC_ASYNC, process) < 1)
+    wxExecuteEnv env{.cwd = m_dir};
+    if (wxExecute(cmd, wxEXEC_ASYNC, process, &env) < 1)
     {
         Log("Command execution failed!", *wxRED);
         m_msgQueue.Post(ExecutorThread::ThreadMessage::ExitThread);
@@ -452,7 +453,9 @@ bool AssemblyBuilderDialog::DoBuild()
         Abandon();
         return false;
     }
-    if (wxExecute(cmd, wxEXEC_ASYNC, process) < 1)
+
+    wxExecuteEnv env{.cwd = m_dir};
+    if (wxExecute(cmd, wxEXEC_ASYNC, process, &env) < 1)
     {
         Log("Command execution failed.", *wxRED);
         Abandon();
@@ -463,20 +466,27 @@ bool AssemblyBuilderDialog::DoBuild()
 
 bool AssemblyBuilderDialog::DoFixChecksum()
 {
+    wxString originalDir = wxGetCwd();
+    wxSetWorkingDirectory(m_dir);
+
+    Log("Fixing ROM checksum...\n", *wxBLUE);
+    bool isSuccess;
     if (wxFileName(outname).Exists())
     {
-        Log("Fixing ROM checksum...\n", *wxBLUE);
         auto r = Rom(outname.ToStdString());
         r.writeFile(outname.ToStdString());
 
         Log(StrPrintf("Done! Checksum is 0x%04X.\n", r.read_checksum()), wxColor(0, 128, 0));
-        return true;
+        isSuccess = true;
     }
     else
     {
-        Log(wxString("Failed to read ROM file \"") + outname + "\".");
+        Log(wxString("Failed to read ROM file \"") + outname + "\" while checking checksum. ", *wxRED);
+        isSuccess = false;
     }
-    return false;
+
+    wxSetWorkingDirectory(originalDir);
+    return isSuccess;
 }
 
 bool AssemblyBuilderDialog::DoRun(const wxString& fname, bool post_build)
@@ -490,7 +500,8 @@ bool AssemblyBuilderDialog::DoRun(const wxString& fname, bool post_build)
     {
         cmd << " \"" << fname << "\"";
         Log(cmd + "\n", *wxBLUE);
-        if (wxExecute(cmd, wxEXEC_ASYNC) < 1)
+
+        if (wxExecute(cmd, wxEXEC_ASYNC, nullptr) < 1)
         {
             Log("Command execution failed.", *wxRED);
             return false;

--- a/src/user_interface/misc/src/AssemblyBuilderDialog.cpp
+++ b/src/user_interface/misc/src/AssemblyBuilderDialog.cpp
@@ -397,7 +397,8 @@ bool AssemblyBuilderDialog::DoClone()
         return false;
     }
 
-    wxExecuteEnv env{.cwd = m_dir};
+    wxExecuteEnv env;
+    env.cwd = m_dir;
     if (wxExecute(cmd, wxEXEC_ASYNC, process, &env) < 1)
     {
         Log("Command execution failed!", *wxRED);
@@ -454,7 +455,8 @@ bool AssemblyBuilderDialog::DoBuild()
         return false;
     }
 
-    wxExecuteEnv env{.cwd = m_dir};
+    wxExecuteEnv env;
+    env.cwd = m_dir;
     if (wxExecute(cmd, wxEXEC_ASYNC, process, &env) < 1)
     {
         Log("Command execution failed.", *wxRED);


### PR DESCRIPTION
When an .asm is loaded `./landstalker_editor disasm/landstalker_us.asm` the `Build assembly... F5` command will fail because the `assets_packed` and `code` are saved at a wrong location, under a sub-directory with same name of the opened asm dir, in this case `disasm/disasm`

`AssemblyBuilderDialog::Assemble` changes the working directory l.267 this will affect `DoSave` call l.273, which also uses the `m_dir` member variable to save the code.  `DoBuild` call need to have the current directory changed beforehand to call the assembler. 

Depending in the build Steps (clone, run...) the working dir need the change of working dir, on other build steps they don't.

Working directory need to be guaranteed on each steps, this PR fix this problem by removing the `wxSetWorkingDirectory(m_dir);` calls, the `wxExecute` calls now use environment variable `env.cwd` 

`AssemblyBuilderDialog::DoFixChecksum` is a little different and do use `wxSetWorkingDirectory` but will restore the working directory . 