### PR TITLE
Heightmap multiple selection

### DIFF
--- a/src/user_interface/rooms/include/HeightmapEditorCtrl.h
+++ b/src/user_interface/rooms/include/HeightmapEditorCtrl.h
@@ -113,6 +113,9 @@ public:
 	bool HandleLeftDown(unsigned int modifiers);
 	bool HandleLeftDClick(unsigned int modifiers);
 	bool HandleRightDown(unsigned int modifiers);
+
+	bool AllSelectedMaxHeight();
+	bool AllSelectedMinHeight();
 private:
 	void RefreshStatusbar();
 	void RefreshCursor(bool ctrl_down);

--- a/src/user_interface/rooms/include/HeightmapEditorCtrl.h
+++ b/src/user_interface/rooms/include/HeightmapEditorCtrl.h
@@ -73,6 +73,7 @@ public:
 	void SetSelection(int ix, int iy);
 	std::pair<int, int> GetSelection(int index) const;
 	
+	bool IsSingleSelection() const;
 	bool IsMultipleSelection() const;
 	bool IsSelectionValid() const;
 	bool AnySelectedMaxHeight();

--- a/src/user_interface/rooms/include/HeightmapEditorCtrl.h
+++ b/src/user_interface/rooms/include/HeightmapEditorCtrl.h
@@ -75,7 +75,7 @@ public:
 	
 	bool IsSingleSelection() const;
 	bool IsMultipleSelection() const;
-	bool IsSelectionValid() const;
+	bool IsSelectionEmpty() const;
 	bool AnySelectedMaxHeight();
 	bool AnySelectedMinHeight();
 

--- a/src/user_interface/rooms/include/HeightmapEditorCtrl.h
+++ b/src/user_interface/rooms/include/HeightmapEditorCtrl.h
@@ -114,8 +114,8 @@ public:
 	bool HandleLeftDClick(unsigned int modifiers);
 	bool HandleRightDown(unsigned int modifiers);
 
-	bool AllSelectedMaxHeight();
-	bool AllSelectedMinHeight();
+	bool AnySelectedMaxHeight();
+	bool AnySelectedMinHeight();
 private:
 	void RefreshStatusbar();
 	void RefreshCursor(bool ctrl_down);

--- a/src/user_interface/rooms/include/HeightmapEditorCtrl.h
+++ b/src/user_interface/rooms/include/HeightmapEditorCtrl.h
@@ -5,6 +5,7 @@
 #include <wx/window.h>
 #include <memory>
 #include <cstdint>
+#include <algorithm>
 #include <landstalker/main/include/ImageBuffer.h>
 #include <landstalker/main/include/GameData.h>
 #include <landstalker/3d_maps/include/Tilemap3DCmp.h>

--- a/src/user_interface/rooms/include/HeightmapEditorCtrl.h
+++ b/src/user_interface/rooms/include/HeightmapEditorCtrl.h
@@ -71,7 +71,12 @@ public:
 	void ClearSelection();
 	void SetSelection(int ix, int iy);
 	std::pair<int, int> GetSelection(int index) const;
+	
+	bool IsMultipleSelection() const;
 	bool IsSelectionValid() const;
+	bool AnySelectedMaxHeight();
+	bool AnySelectedMinHeight();
+
 	void NudgeSelectionUp();
 	void NudgeSelectionDown();
 	void NudgeSelectionLeft();
@@ -114,8 +119,7 @@ public:
 	bool HandleLeftDClick(unsigned int modifiers);
 	bool HandleRightDown(unsigned int modifiers);
 
-	bool AnySelectedMaxHeight();
-	bool AnySelectedMinHeight();
+
 private:
 	void RefreshStatusbar();
 	void RefreshCursor(bool ctrl_down);

--- a/src/user_interface/rooms/include/HeightmapEditorCtrl.h
+++ b/src/user_interface/rooms/include/HeightmapEditorCtrl.h
@@ -70,7 +70,7 @@ public:
 
 	void ClearSelection();
 	void SetSelection(int ix, int iy);
-	std::pair<int, int> GetSelection() const;
+	std::pair<int, int> GetSelection(int index) const;
 	bool IsSelectionValid() const;
 	void NudgeSelectionUp();
 	void NudgeSelectionDown();
@@ -87,14 +87,14 @@ public:
 	void InsertColumnRight();
 	void DeleteColumn();
 
-	uint8_t GetSelectedHeight(int selectedIndex) const;
-	void SetSelectedHeight(int selectedIndex, uint8_t height);
+	uint8_t GetSelectedHeight(int index) const;
+	void SetSelectedHeight(int index, uint8_t height);
 	void IncreaseHeight();
 	void DecreaseSelectedHeight();
 	void ClearSelectedCell();
 
-	uint8_t GetSelectedRestrictions() const;
-	void SetSelectedRestrictions(uint8_t restrictions);
+	uint8_t GetSelectedRestrictions(int index) const;
+	void SetSelectedRestrictions(int index, uint8_t restrictions);
 	bool IsSelectedPlayerPassable() const;
 	void ToggleSelectedPlayerPassable();
 	bool IsSelectedNPCPassable() const;
@@ -104,8 +104,8 @@ public:
 	void IncrementSelectedRestrictions();
 	void DecrementSelectedRestrictions();
 
-	uint8_t GetSelectedType() const;
-	void SetSelectedType(uint8_t type);
+	uint8_t GetSelectedType(int index) const;
+	void SetSelectedType(int index, uint8_t type);
 	void IncrementSelectedType();
 	void DecrementSelectedType();
 

--- a/src/user_interface/rooms/include/HeightmapEditorCtrl.h
+++ b/src/user_interface/rooms/include/HeightmapEditorCtrl.h
@@ -87,9 +87,9 @@ public:
 	void InsertColumnRight();
 	void DeleteColumn();
 
-	uint8_t GetSelectedHeight() const;
-	void SetSelectedHeight(uint8_t height);
-	void IncreaseSelectedHeight();
+	uint8_t GetSelectedHeight(int selectedIndex) const;
+	void SetSelectedHeight(int selectedIndex, uint8_t height);
+	void IncreaseHeight();
 	void DecreaseSelectedHeight();
 	void ClearSelectedCell();
 
@@ -186,7 +186,7 @@ private:
 	bool m_redraw;
 	bool m_repaint;
 	double m_zoom;
-	Coord m_selected;
+	std::vector<Coord> m_selected;
 	Coord m_hovered;
 	Coord m_cpysrc;
 	Coord m_dragged;

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1313,6 +1313,16 @@ bool HeightmapEditorCtrl::HandleRightDown(unsigned int modifiers)
     return false;
 }
 
+bool HeightmapEditorCtrl::AllSelectedMaxHeight()
+{
+    return std::all_of(m_selected.begin(), m_selected.end(), [&, i = 0](const auto&) mutable { return GetSelectedHeight(i++) < 15; });
+}
+
+bool HeightmapEditorCtrl::AllSelectedMinHeight()
+{
+    return std::all_of(m_selected.begin(), m_selected.end(), [&, i = 0](const auto&) mutable { return GetSelectedHeight(i++) > 0; });
+}
+
 void HeightmapEditorCtrl::RefreshStatusbar()
 {
     std::string msg = "";

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1060,9 +1060,7 @@ uint8_t HeightmapEditorCtrl::GetSelectedRestrictions(int index) const
 
 void HeightmapEditorCtrl::SetSelectedRestrictions(int index, uint8_t restrictions)
 {
-    for (const auto& coord : m_selected) {
-        m_map->SetCellProps({ coord.first, coord.second }, restrictions);
-    }
+    m_map->SetCellProps({ m_selected[index].first, m_selected[index].second }, restrictions);
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);
 }
@@ -1315,7 +1313,6 @@ bool HeightmapEditorCtrl::HandleRightDown(unsigned int modifiers)
 
 bool HeightmapEditorCtrl::AnySelectedMaxHeight()
 {
-    std::cout << "AllSelectedMaxHeight" << std::endl; 
     return std::any_of(m_selected.begin(), m_selected.end(), [&, i = 0](const auto&) mutable { return GetSelectedHeight(i++) < 15; });
 }
 

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1073,8 +1073,13 @@ bool HeightmapEditorCtrl::IsSelectedPlayerPassable() const
 
 void HeightmapEditorCtrl::ToggleSelectedPlayerPassable()
 {
+    bool hasFlag = IsSelectedPlayerPassable();
     for (size_t i = 0; i < m_selected.size(); ++i) {
-        SetSelectedRestrictions(i, GetSelectedRestrictions(i) ^ 0x04);
+        if (hasFlag) {
+            SetSelectedRestrictions(i, GetSelectedRestrictions(i) | 0x04);
+        } else {
+            SetSelectedRestrictions(i, GetSelectedRestrictions(i) & ~0x04);
+        }
     }
 }
 
@@ -1090,8 +1095,13 @@ bool HeightmapEditorCtrl::IsSelectedNPCPassable() const
 
 void HeightmapEditorCtrl::ToggleSelectedNPCPassable()
 {
+    bool hasFlag = IsSelectedNPCPassable();
     for (size_t i = 0; i < m_selected.size(); ++i) {
-        SetSelectedRestrictions(i, GetSelectedRestrictions(i) ^ 0x02);
+        if (hasFlag) {
+            SetSelectedRestrictions(i, GetSelectedRestrictions(i) | 0x02);
+        } else {
+            SetSelectedRestrictions(i, GetSelectedRestrictions(i) & ~0x02);
+        }
     }
 }
 
@@ -1107,8 +1117,13 @@ bool HeightmapEditorCtrl::IsSelectedRaftTrack() const
 
 void HeightmapEditorCtrl::ToggleSelectedRaftTrack()
 {
+    bool hasFlag = IsSelectedRaftTrack();
     for (size_t i = 0; i < m_selected.size(); ++i) {
-        SetSelectedRestrictions(i, GetSelectedRestrictions(i) ^ 0x01);
+        if (hasFlag) {
+            SetSelectedRestrictions(i, GetSelectedRestrictions(i) | 0x01);
+        } else {
+            SetSelectedRestrictions(i, GetSelectedRestrictions(i) & ~0x01);
+        }
     }
 }
 

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1045,9 +1045,9 @@ void HeightmapEditorCtrl::DecreaseSelectedHeight()
 void HeightmapEditorCtrl::ClearSelectedCell()
 {
     for (size_t i = 0; i < m_selected.size(); ++i) {
-        m_map->SetHeight({ m_selected[i].first, m_selected[0].second }, 0);
-        m_map->SetCellProps({ m_selected[i].first, m_selected[0].second }, 4);
-        m_map->SetCellType({ m_selected[i].first, m_selected[0].second }, 0);
+        m_map->SetHeight({ m_selected[i].first, m_selected[i].second }, 0);
+        m_map->SetCellProps({ m_selected[i].first, m_selected[i].second }, 4);
+        m_map->SetCellType({ m_selected[i].first, m_selected[i].second }, 0);
     }
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1286,7 +1286,7 @@ bool HeightmapEditorCtrl::HandleRightDown(unsigned int modifiers)
 {
     if ((modifiers & wxMOD_CONTROL) == 0)
     {
-        if (m_selected[0] != m_hovered)
+        if (IsSingleSelection() && m_selected[0] != m_hovered)
         {
             m_selected[0] = m_hovered;
             m_cpysrc = m_selected[0];

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -758,6 +758,11 @@ std::pair<int, int> HeightmapEditorCtrl::GetSelection(int index) const
     return m_selected[index];
 }
 
+bool HeightmapEditorCtrl::IsSingleSelection() const
+{
+    return m_selected.size() == 1;
+}
+
 bool HeightmapEditorCtrl::IsMultipleSelection() const
 {
     return m_selected.size() > 1;

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1259,20 +1259,20 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
     }
     else
     {
-        //if (m_selected[0] != m_hovered)
-        //{
+        if (m_cpysrc.first != -1)
+        {
+            m_map->SetHeight({ m_hovered.first, m_hovered.second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
+            m_map->SetCellProps({ m_hovered.first, m_hovered.second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
+            m_map->SetCellType({ m_hovered.first, m_hovered.second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
+            FireEvent(EVT_HEIGHTMAP_UPDATE);
+        }
+        else
+        {
             m_selected.clear();
             m_selected.push_back(m_hovered);
             FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-            if (m_cpysrc.first != -1 && m_selected[0].first != -1 && m_selected[0] != m_cpysrc)
-            {
-                m_map->SetHeight({ m_selected[0].first, m_selected[0].second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
-                m_map->SetCellProps({ m_selected[0].first, m_selected[0].second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
-                m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
-                FireEvent(EVT_HEIGHTMAP_UPDATE);
-            }
-            ForceRedraw();
-        //}
+        }
+        ForceRedraw();
     }
     return false;
 }
@@ -1286,12 +1286,8 @@ bool HeightmapEditorCtrl::HandleRightDown(unsigned int modifiers)
 {
     if ((modifiers & wxMOD_CONTROL) == 0)
     {
-        if (IsSingleSelection() && m_selected[0] != m_hovered)
-        {
-            m_selected[0] = m_hovered;
-            m_cpysrc = m_selected[0];
-            Refresh(false);
-        }
+        m_cpysrc = m_hovered;
+        Refresh(false);
     }
     else
     {

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -35,7 +35,7 @@ HeightmapEditorCtrl::HeightmapEditorCtrl(wxWindow* parent, RoomViewerFrame* fram
       m_redraw(false),
       m_repaint(false),
       m_zoom(1.0),
-      m_selected(-1, -1),
+      m_selected{Coord{-1, -1}},
       m_hovered(-1, -1),
       m_cpysrc(-1, -1),
       m_dragged(-1, -1),
@@ -248,7 +248,7 @@ bool HeightmapEditorCtrl::HandleKeyDown(unsigned int key, unsigned int modifiers
     if (key == WXK_ESCAPE)
     {
         StopDrag(true);
-        m_selected = { -1, -1 };
+        m_selected[0] = { -1, -1 };
         m_hovered = { -1, -1 };
         SetSelectedSwap(-1);
         SetSelectedDoor(-1);
@@ -635,7 +635,7 @@ bool HeightmapEditorCtrl::HandleDrawKeyDown(unsigned int key, unsigned int modif
         }
         return false;
     case WXK_PAGEUP:
-        IncreaseSelectedHeight();
+        IncreaseHeight();
         return false;
     case WXK_PAGEDOWN:
         DecreaseSelectedHeight();
@@ -691,8 +691,8 @@ bool HeightmapEditorCtrl::HandleDrawKeyDown(unsigned int key, unsigned int modif
     case '7':
     case '8':
     case '9':
-        SetSelectedHeight(key - '0');
-        return false;
+        //SetSelectedHeight(key - '0');
+        //return false;
     case WXK_NUMPAD0:
     case WXK_NUMPAD1:
     case WXK_NUMPAD2:
@@ -703,7 +703,7 @@ bool HeightmapEditorCtrl::HandleDrawKeyDown(unsigned int key, unsigned int modif
     case WXK_NUMPAD7:
     case WXK_NUMPAD8:
     case WXK_NUMPAD9:
-        SetSelectedHeight(key - WXK_NUMPAD0);
+        //SetSelectedHeight(key - WXK_NUMPAD0);
         return false;
     case WXK_DELETE:
         if (modifiers == (wxMOD_SHIFT | wxMOD_ALT))
@@ -725,9 +725,9 @@ bool HeightmapEditorCtrl::HandleDrawKeyDown(unsigned int key, unsigned int modif
 
 void HeightmapEditorCtrl::ClearSelection()
 {
-    if (m_selected.first != -1)
+    if (m_selected[0].first != -1)
     {
-        m_selected = { -1, -1 };
+        m_selected[0] = { -1, -1 };
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
         Refresh(false);
     }
@@ -735,11 +735,11 @@ void HeightmapEditorCtrl::ClearSelection()
 
 void HeightmapEditorCtrl::SetSelection(int ix, int iy)
 {
-    if (m_selected.first != ix || m_selected.second != iy)
+    if (m_selected[0].first != ix || m_selected[0].second != iy)
     {
         if (ix >= 0 && ix < m_map->GetHeightmapWidth() && iy >= 0 && iy < m_map->GetHeightmapWidth())
         {
-            m_selected = { ix, iy };
+            m_selected[0] = { ix, iy };
             FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
             Refresh(false);
         }
@@ -752,29 +752,29 @@ void HeightmapEditorCtrl::SetSelection(int ix, int iy)
 
 std::pair<int, int> HeightmapEditorCtrl::GetSelection() const
 {
-    return m_selected;
+    return m_selected[0];
 }
 
 bool HeightmapEditorCtrl::IsSelectionValid() const
 {
-    return m_selected.first != -1;
+    return m_selected[0].first != -1;
 }
 
 void HeightmapEditorCtrl::NudgeSelectionUp()
 {
     bool upd = false;
-    if (m_selected.first == -1 && m_hovered.first == -1)
+    if (m_selected[0].first == -1 && m_hovered.first == -1)
     {
-        m_selected = { 0, 0 };
+        m_selected[0] = { 0, 0 };
         upd = true;
     }
-    else if (m_selected.first > 0)
+    else if (m_selected[0].first > 0)
     {
-        if (m_selected.first == -1)
+        if (m_selected[0].first == -1)
         {
-            m_selected = m_hovered;
+            m_selected[0] = m_hovered;
         }
-        m_selected.first--;
+        m_selected[0].first--;
         upd = true;
     }
     if (upd)
@@ -787,18 +787,18 @@ void HeightmapEditorCtrl::NudgeSelectionUp()
 void HeightmapEditorCtrl::NudgeSelectionDown()
 {
     bool upd = false;
-    if (m_selected.first == -1 && m_hovered.first == -1)
+    if (m_selected[0].first == -1 && m_hovered.first == -1)
     {
-        m_selected = { 0, 0 };
+        m_selected[0] = { 0, 0 };
         upd = true;
     }
-    else if (m_selected.first < m_map->GetHeightmapWidth() - 1)
+    else if (m_selected[0].first < m_map->GetHeightmapWidth() - 1)
     {
-        if (m_selected.first == -1)
+        if (m_selected[0].first == -1)
         {
-            m_selected = m_hovered;
+            m_selected[0] = m_hovered;
         }
-        m_selected.first++;
+        m_selected[0].first++;
         upd = true;
     }
     if (upd)
@@ -811,18 +811,18 @@ void HeightmapEditorCtrl::NudgeSelectionDown()
 void HeightmapEditorCtrl::NudgeSelectionLeft()
 {
     bool upd = false;
-    if (m_selected.first == -1 && m_hovered.first == -1)
+    if (m_selected[0].first == -1 && m_hovered.first == -1)
     {
-        m_selected = { 0, 0 };
+        m_selected[0] = { 0, 0 };
         upd = true;
     }
-    else if (m_selected.second < m_map->GetHeightmapHeight() - 1)
+    else if (m_selected[0].second < m_map->GetHeightmapHeight() - 1)
     {
-        if (m_selected.first == -1)
+        if (m_selected[0].first == -1)
         {
-            m_selected = m_hovered;
+            m_selected[0] = m_hovered;
         }
-        m_selected.second++;
+        m_selected[0].second++;
         upd = true;
     }
     if (upd)
@@ -835,18 +835,18 @@ void HeightmapEditorCtrl::NudgeSelectionLeft()
 void HeightmapEditorCtrl::NudgeSelectionRight()
 {
     bool upd = false;
-    if (m_selected.first == -1 && m_hovered.first == -1)
+    if (m_selected[0].first == -1 && m_hovered.first == -1)
     {
-        m_selected = { 0, 0 };
+        m_selected[0] = { 0, 0 };
         upd = true;
     }
-    else if (m_selected.second > 0)
+    else if (m_selected[0].second > 0)
     {
-        if (m_selected.first == -1)
+        if (m_selected[0].first == -1)
         {
-            m_selected = m_hovered;
+            m_selected[0] = m_hovered;
         }
-        m_selected.second--;
+        m_selected[0].second--;
         upd = true;
     }
     if (upd)
@@ -902,10 +902,10 @@ void HeightmapEditorCtrl::NudgeHeightmapRight()
 
 void HeightmapEditorCtrl::InsertRowAbove()
 {
-    if (m_selected.second != -1 && m_map->GetHeightmapWidth() < 64)
+    if (m_selected[0].second != -1 && m_map->GetHeightmapWidth() < 64)
     {
-        m_map->InsertHeightmapRow(m_selected.first);
-        m_selected.first++;
+        m_map->InsertHeightmapRow(m_selected[0].first);
+        m_selected[0].first++;
         RecreateBuffer();
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
         FireEvent(EVT_HEIGHTMAP_UPDATE);
@@ -915,9 +915,9 @@ void HeightmapEditorCtrl::InsertRowAbove()
 
 void HeightmapEditorCtrl::InsertRowBelow()
 {
-    if (m_selected.first != -1 && m_map->GetHeightmapWidth() < 64)
+    if (m_selected[0].first != -1 && m_map->GetHeightmapWidth() < 64)
     {
-        m_map->InsertHeightmapRow(m_selected.first);
+        m_map->InsertHeightmapRow(m_selected[0].first);
         RecreateBuffer();
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
         FireEvent(EVT_HEIGHTMAP_UPDATE);
@@ -927,12 +927,12 @@ void HeightmapEditorCtrl::InsertRowBelow()
 
 void HeightmapEditorCtrl::DeleteRow()
 {
-    if (m_selected.first != -1 && m_map->GetHeightmapWidth() > 1)
+    if (m_selected[0].first != -1 && m_map->GetHeightmapWidth() > 1)
     {
-        m_map->DeleteHeightmapRow(m_selected.first);
-        if (m_selected.first >= m_map->GetHeightmapWidth())
+        m_map->DeleteHeightmapRow(m_selected[0].first);
+        if (m_selected[0].first >= m_map->GetHeightmapWidth())
         {
-            m_selected.first = m_map->GetHeightmapWidth() - 1;
+            m_selected[0].first = m_map->GetHeightmapWidth() - 1;
         }
         RecreateBuffer();
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
@@ -943,9 +943,9 @@ void HeightmapEditorCtrl::DeleteRow()
 
 void HeightmapEditorCtrl::InsertColumnLeft()
 {
-    if (m_selected.first != -1 && m_map->GetHeightmapHeight() < 64)
+    if (m_selected[0].first != -1 && m_map->GetHeightmapHeight() < 64)
     {
-        m_map->InsertHeightmapColumn(m_selected.second);
+        m_map->InsertHeightmapColumn(m_selected[0].second);
         RecreateBuffer();
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
         FireEvent(EVT_HEIGHTMAP_UPDATE);
@@ -955,10 +955,10 @@ void HeightmapEditorCtrl::InsertColumnLeft()
 
 void HeightmapEditorCtrl::InsertColumnRight()
 {
-    if (m_selected.second != -1 && m_map->GetHeightmapHeight() < 64)
+    if (m_selected[0].second != -1 && m_map->GetHeightmapHeight() < 64)
     {
-        m_map->InsertHeightmapColumn(m_selected.second);
-        m_selected.second++;
+        m_map->InsertHeightmapColumn(m_selected[0].second);
+        m_selected[0].second++;
         RecreateBuffer();
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
         FireEvent(EVT_HEIGHTMAP_UPDATE);
@@ -968,12 +968,12 @@ void HeightmapEditorCtrl::InsertColumnRight()
 
 void HeightmapEditorCtrl::DeleteColumn()
 {
-    if (m_selected.first != -1 && m_map->GetHeightmapHeight() > 1)
+    if (m_selected[0].first != -1 && m_map->GetHeightmapHeight() > 1)
     {
-        m_map->DeleteHeightmapColumn(m_selected.second);
-        if (m_selected.second >= m_map->GetHeightmapHeight())
+        m_map->DeleteHeightmapColumn(m_selected[0].second);
+        if (m_selected[0].second >= m_map->GetHeightmapHeight())
         {
-            m_selected.second = m_map->GetHeightmapHeight() - 1;
+            m_selected[0].second = m_map->GetHeightmapHeight() - 1;
         }
         RecreateBuffer();
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
@@ -982,55 +982,61 @@ void HeightmapEditorCtrl::DeleteColumn()
     }
 }
 
-uint8_t HeightmapEditorCtrl::GetSelectedHeight() const
+uint8_t HeightmapEditorCtrl::GetSelectedHeight(int selectedIndex) const
 {
-    return m_map->GetHeight({ m_selected.first, m_selected.second });
+    return m_map->GetHeight({ m_selected[selectedIndex].first, m_selected[selectedIndex].second });
 }
 
-void HeightmapEditorCtrl::SetSelectedHeight(uint8_t height)
+void HeightmapEditorCtrl::SetSelectedHeight(int selectedIndex, uint8_t height)
 {
-    m_map->SetHeight({ m_selected.first, m_selected.second }, height);
+    m_map->SetHeight({ m_selected[selectedIndex].first, m_selected[selectedIndex].second }, height);
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);
 }
 
-void HeightmapEditorCtrl::IncreaseSelectedHeight()
+void HeightmapEditorCtrl::IncreaseHeight()
 {
-    uint8_t height = GetSelectedHeight();
-    if (height < 15)
-    {
-        ++height;
+    for (size_t i = 0; i < m_selected.size(); ++i) {
+        uint8_t height = GetSelectedHeight(i);
+        if (height < 15)
+        {
+            ++height;
+        }
+        SetSelectedHeight(i, height);
     }
-    SetSelectedHeight(height);
 }
 
 void HeightmapEditorCtrl::DecreaseSelectedHeight()
 {
-    uint8_t height = GetSelectedHeight();
-    if (height > 0)
-    {
-        --height;
+    for (size_t i = 0; i < m_selected.size(); ++i) {
+        uint8_t height = GetSelectedHeight(i);
+        if (height > 0)
+        {
+            --height;
+        }
+        SetSelectedHeight(i, height);
     }
-    SetSelectedHeight(height);
 }
 
 void HeightmapEditorCtrl::ClearSelectedCell()
 {
-    m_map->SetHeight({ m_selected.first, m_selected.second }, 0);
-    m_map->SetCellProps({ m_selected.first, m_selected.second }, 4);
-    m_map->SetCellType({ m_selected.first, m_selected.second }, 0);
+    m_map->SetHeight({ m_selected[0].first, m_selected[0].second }, 0);
+    m_map->SetCellProps({ m_selected[0].first, m_selected[0].second }, 4);
+    m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, 0);
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);
 }
 
 uint8_t HeightmapEditorCtrl::GetSelectedRestrictions() const
 {
-    return m_map->GetCellProps({ m_selected.first, m_selected.second });
+    return m_map->GetCellProps({ m_selected[0].first, m_selected[0].second });
 }
 
 void HeightmapEditorCtrl::SetSelectedRestrictions(uint8_t restrictions)
 {
-    m_map->SetCellProps({ m_selected.first, m_selected.second }, restrictions);
+    for (const auto& coord : m_selected) {
+        m_map->SetCellProps({ coord.first, coord.second }, restrictions);
+    }
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);
 }
@@ -1077,12 +1083,12 @@ void HeightmapEditorCtrl::DecrementSelectedRestrictions()
 
 uint8_t HeightmapEditorCtrl::GetSelectedType() const
 {
-    return m_map->GetCellType({m_selected.first, m_selected.second});
+    return m_map->GetCellType({m_selected[0].first, m_selected[0].second});
 }
 
 void HeightmapEditorCtrl::SetSelectedType(uint8_t type)
 {
-    m_map->SetCellType({ m_selected.first, m_selected.second }, type);
+    m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, type);
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);
 }
@@ -1168,17 +1174,41 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
         }
         Refresh();
     }
+    else if ((modifiers & wxMOD_SHIFT) > 0)
+    {
+        // Multiple selection
+        auto it = std::find(m_selected.begin(), m_selected.end(), m_hovered);
+        if (it != m_selected.end()) {
+            m_selected.erase(it);
+        }
+        else
+        {
+            m_selected.push_back(m_hovered);
+        }
+
+        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+        if (m_cpysrc.first != -1 && m_selected[0].first != -1 && m_selected[0] != m_cpysrc)
+        {
+            m_map->SetHeight({ m_selected[0].first, m_selected[0].second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
+            m_map->SetCellProps({ m_selected[0].first, m_selected[0].second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
+            m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
+            FireEvent(EVT_HEIGHTMAP_UPDATE);
+        }
+        ForceRedraw();
+
+    }
     else
     {
-        if (m_selected != m_hovered)
+        if (m_selected[0] != m_hovered)
         {
-            m_selected = m_hovered;
+            m_selected.clear();
+            m_selected.push_back(m_hovered);
             FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-            if (m_cpysrc.first != -1 && m_selected.first != -1 && m_selected != m_cpysrc)
+            if (m_cpysrc.first != -1 && m_selected[0].first != -1 && m_selected[0] != m_cpysrc)
             {
-                m_map->SetHeight({ m_selected.first, m_selected.second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
-                m_map->SetCellProps({ m_selected.first, m_selected.second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
-                m_map->SetCellType({ m_selected.first, m_selected.second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
+                m_map->SetHeight({ m_selected[0].first, m_selected[0].second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
+                m_map->SetCellProps({ m_selected[0].first, m_selected[0].second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
+                m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
                 FireEvent(EVT_HEIGHTMAP_UPDATE);
             }
             ForceRedraw();
@@ -1196,10 +1226,10 @@ bool HeightmapEditorCtrl::HandleRightDown(unsigned int modifiers)
 {
     if ((modifiers & wxMOD_CONTROL) == 0)
     {
-        if (m_selected != m_hovered)
+        if (m_selected[0] != m_hovered)
         {
-            m_selected = m_hovered;
-            m_cpysrc = m_selected;
+            m_selected[0] = m_hovered;
+            m_cpysrc = m_selected[0];
             Refresh(false);
         }
     }
@@ -1470,7 +1500,9 @@ void HeightmapEditorCtrl::DrawEntities(wxDC& dc)
 void HeightmapEditorCtrl::DrawSelectionCursors(wxDC& dc)
 {
     auto lines = GetTilePoly(0, 0);
-    if (m_hovered.first != -1 && m_hovered != m_selected)
+
+    // Draw cursor for hovered tile
+    if (m_hovered.first != -1 && std::find(m_selected.begin(), m_selected.end(), m_hovered) == m_selected.end())
     {
         int x = (m_map->GetHeightmapHeight() + m_hovered.first - m_hovered.second - 1) * TILE_WIDTH / 2;
         int y = (m_hovered.first + m_hovered.second) * TILE_HEIGHT / 2;
@@ -1478,15 +1510,22 @@ void HeightmapEditorCtrl::DrawSelectionCursors(wxDC& dc)
         dc.SetBrush(*wxTRANSPARENT_BRUSH);
         dc.DrawPolygon(lines.size(), lines.data(), x, y);
     }
-    if (m_selected.first != -1 && m_hovered != m_selected)
+
+    // Draw cursor for each selected tile
+    for (const auto& coord : m_selected)
     {
-        int x = (m_map->GetHeightmapHeight() + m_selected.first - m_selected.second - 1) * TILE_WIDTH / 2;
-        int y = (m_selected.first + m_selected.second) * TILE_HEIGHT / 2;
-        dc.SetPen(*wxYELLOW_PEN);
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawPolygon(lines.size(), lines.data(), x, y);
+        if (coord.first != -1 && coord != m_hovered)
+        {
+            int x = (m_map->GetHeightmapHeight() + coord.first - coord.second - 1) * TILE_WIDTH / 2;
+            int y = (coord.first + coord.second) * TILE_HEIGHT / 2;
+            dc.SetPen(*wxYELLOW_PEN);
+            dc.SetBrush(*wxTRANSPARENT_BRUSH);
+            dc.DrawPolygon(lines.size(), lines.data(), x, y);
+        }
     }
-    if (m_selected.first != -1 && m_hovered == m_selected)
+
+    // Draw cursor if hovered tile is also selected
+    if (m_hovered.first != -1 && std::find(m_selected.begin(), m_selected.end(), m_hovered) != m_selected.end())
     {
         int x = (m_map->GetHeightmapHeight() + m_hovered.first - m_hovered.second - 1) * TILE_WIDTH / 2;
         int y = (m_hovered.first + m_hovered.second) * TILE_HEIGHT / 2;
@@ -1494,6 +1533,8 @@ void HeightmapEditorCtrl::DrawSelectionCursors(wxDC& dc)
         dc.SetBrush(*wxTRANSPARENT_BRUSH);
         dc.DrawPolygon(lines.size(), lines.data(), x, y);
     }
+
+    // Draw cursor for the copy source tile
     if (m_cpysrc.first != -1)
     {
         std::unique_ptr<wxPen> m_cpysrc_pen(new wxPen(*wxCYAN, 1, wxPENSTYLE_SHORT_DASH));
@@ -1504,6 +1545,7 @@ void HeightmapEditorCtrl::DrawSelectionCursors(wxDC& dc)
         dc.DrawPolygon(lines.size(), lines.data(), x, y);
     }
 }
+
 
 void HeightmapEditorCtrl::SetOpacity(wxImage& image, uint8_t opacity)
 {
@@ -1536,9 +1578,9 @@ bool HeightmapEditorCtrl::UpdateHoveredPosition(int screenx, int screeny)
 bool HeightmapEditorCtrl::UpdateSelectedPosition(int screenx, int screeny)
 {
     auto i = GetHMPosition(screenx, screeny);
-    if (m_selected.first != i.first || m_selected.second != i.second)
+    if (m_selected[0].first != i.first || m_selected[0].second != i.second)
     {
-        m_selected = i;
+        m_selected[0] = i;
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
         return true;
     }
@@ -1611,9 +1653,9 @@ void HeightmapEditorCtrl::RecreateBuffer()
     {
         m_hovered = { -1, -1 };
     }
-    if (!IsCoordValid(m_selected))
+    if (!IsCoordValid(m_selected[0]))
     {
-        m_selected = { -1, -1 };
+        m_selected[0] = { -1, -1 };
     }
     m_cpysrc = {-1, -1};
     RefreshGraphics();
@@ -1804,11 +1846,11 @@ std::pair<int, int> HeightmapEditorCtrl::GetHMPosition(int screenx, int screeny)
 void HeightmapEditorCtrl::OnLeftClick(wxMouseEvent& evt)
 {
     UpdateSelectedPosition(evt.GetX(), evt.GetY());
-    if (m_cpysrc.first != -1 && m_selected.first != -1 && m_selected != m_cpysrc)
+    if (m_cpysrc.first != -1 && m_selected[0].first != -1 && m_selected[0] != m_cpysrc)
     {
-        m_map->SetHeight({ m_selected.first, m_selected.second}, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second}));
-        m_map->SetCellProps({ m_selected.first, m_selected.second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
-        m_map->SetCellType({ m_selected.first, m_selected.second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
+        m_map->SetHeight({ m_selected[0].first, m_selected[0].second}, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second}));
+        m_map->SetCellProps({ m_selected[0].first, m_selected[0].second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
+        m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
         ForceRedraw();
         FireEvent(EVT_HEIGHTMAP_UPDATE);
     }
@@ -1823,7 +1865,7 @@ void HeightmapEditorCtrl::OnRightClick(wxMouseEvent& evt)
 {
     if (UpdateSelectedPosition(evt.GetX(), evt.GetY()))
     {
-        m_cpysrc = m_selected;
+        m_cpysrc = m_selected[0];
         Refresh(false);
     }
     

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -755,6 +755,11 @@ std::pair<int, int> HeightmapEditorCtrl::GetSelection(int index) const
     return m_selected[index];
 }
 
+bool HeightmapEditorCtrl::IsMultipleSelection() const
+{
+    return m_selected.size() > 1;
+}
+
 bool HeightmapEditorCtrl::IsSelectionValid() const
 {
     return !m_selected.empty();

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -939,70 +939,58 @@ void HeightmapEditorCtrl::InsertRowBelow()
 
 void HeightmapEditorCtrl::DeleteRow()
 {
-    if(m_selected.size() == 1)
+    if (m_selected.size() == 1 && m_selected[0].first != -1 && m_map->GetHeightmapWidth() > 1)
     {
-        if (m_selected[0].first != -1 && m_map->GetHeightmapWidth() > 1)
+        m_map->DeleteHeightmapRow(m_selected[0].first);
+        if (m_selected[0].first >= m_map->GetHeightmapWidth())
         {
-            m_map->DeleteHeightmapRow(m_selected[0].first);
-            if (m_selected[0].first >= m_map->GetHeightmapWidth())
-            {
-                m_selected[0].first = m_map->GetHeightmapWidth() - 1;
-            }
-            RecreateBuffer();
-            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-            FireEvent(EVT_HEIGHTMAP_UPDATE);
-            FireEvent(EVT_PROPERTIES_UPDATE);
+            m_selected[0].first = m_map->GetHeightmapWidth() - 1;
         }
+        RecreateBuffer();
+        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+        FireEvent(EVT_HEIGHTMAP_UPDATE);
+        FireEvent(EVT_PROPERTIES_UPDATE);
     }
 }
 
 void HeightmapEditorCtrl::InsertColumnLeft()
 {
-    if(m_selected.size() == 1)
+    if (m_selected.size() == 1 && m_selected[0].first != -1 && m_map->GetHeightmapHeight() < 64)
     {
-        if (m_selected[0].first != -1 && m_map->GetHeightmapHeight() < 64)
-        {
-            m_map->InsertHeightmapColumn(m_selected[0].second);
-            RecreateBuffer();
-            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-            FireEvent(EVT_HEIGHTMAP_UPDATE);
-            FireEvent(EVT_PROPERTIES_UPDATE);
-        }
+        m_map->InsertHeightmapColumn(m_selected[0].second);
+        RecreateBuffer();
+        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+        FireEvent(EVT_HEIGHTMAP_UPDATE);
+        FireEvent(EVT_PROPERTIES_UPDATE);
     }
 }
 
 void HeightmapEditorCtrl::InsertColumnRight()
 {
-    if(m_selected.size() == 1)
+    if (m_selected.size() == 1 && m_selected[0].second != -1 && m_map->GetHeightmapHeight() < 64)
     {
-        if (m_selected[0].second != -1 && m_map->GetHeightmapHeight() < 64)
-        {
-            m_map->InsertHeightmapColumn(m_selected[0].second);
-            m_selected[0].second++;
-            RecreateBuffer();
-            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-            FireEvent(EVT_HEIGHTMAP_UPDATE);
-            FireEvent(EVT_PROPERTIES_UPDATE);
-        }
+        m_map->InsertHeightmapColumn(m_selected[0].second);
+        m_selected[0].second++;
+        RecreateBuffer();
+        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+        FireEvent(EVT_HEIGHTMAP_UPDATE);
+        FireEvent(EVT_PROPERTIES_UPDATE);
     }
 }
 
 void HeightmapEditorCtrl::DeleteColumn()
 {
-    if(m_selected.size() == 1)
+    if (m_selected.size() == 1 && m_selected[0].first != -1 && m_map->GetHeightmapHeight() > 1)
     {
-        if (m_selected[0].first != -1 && m_map->GetHeightmapHeight() > 1)
+        m_map->DeleteHeightmapColumn(m_selected[0].second);
+        if (m_selected[0].second >= m_map->GetHeightmapHeight())
         {
-            m_map->DeleteHeightmapColumn(m_selected[0].second);
-            if (m_selected[0].second >= m_map->GetHeightmapHeight())
-            {
-                m_selected[0].second = m_map->GetHeightmapHeight() - 1;
-            }
-            RecreateBuffer();
-            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-            FireEvent(EVT_HEIGHTMAP_UPDATE);
-            FireEvent(EVT_PROPERTIES_UPDATE);
+            m_selected[0].second = m_map->GetHeightmapHeight() - 1;
         }
+        RecreateBuffer();
+        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+        FireEvent(EVT_HEIGHTMAP_UPDATE);
+        FireEvent(EVT_PROPERTIES_UPDATE);
     }
 }
 

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1261,10 +1261,18 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
     {
         if (m_cpysrc.first != -1)
         {
-            m_map->SetHeight({ m_hovered.first, m_hovered.second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
-            m_map->SetCellProps({ m_hovered.first, m_hovered.second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
-            m_map->SetCellType({ m_hovered.first, m_hovered.second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
-            FireEvent(EVT_HEIGHTMAP_UPDATE);
+            if(m_hovered.first == m_cpysrc.first && m_hovered.second == m_cpysrc.second)
+            {
+                m_cpysrc.first = -1;
+                m_cpysrc.second = -1;
+            }
+            else
+            {
+                m_map->SetHeight({ m_hovered.first, m_hovered.second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
+                m_map->SetCellProps({ m_hovered.first, m_hovered.second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
+                m_map->SetCellType({ m_hovered.first, m_hovered.second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
+                FireEvent(EVT_HEIGHTMAP_UPDATE);
+            }
         }
         else
         {

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -249,6 +249,7 @@ bool HeightmapEditorCtrl::HandleKeyDown(unsigned int key, unsigned int modifiers
         StopDrag(true);
         m_selected.clear();
         m_hovered = { -1, -1 };
+        m_cpysrc = { -1, -1 };
         SetSelectedSwap(-1);
         SetSelectedDoor(-1);
         FireEvent(EVT_TILESWAP_SELECT, -1);
@@ -1263,8 +1264,7 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
         {
             if(m_hovered.first == m_cpysrc.first && m_hovered.second == m_cpysrc.second)
             {
-                m_cpysrc.first = -1;
-                m_cpysrc.second = -1;
+                m_cpysrc = { -1, -1 };
             }
             else
             {

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -914,7 +914,7 @@ void HeightmapEditorCtrl::NudgeHeightmapRight()
 
 void HeightmapEditorCtrl::InsertRowAbove()
 {
-    if (m_selected[0].second != -1 && m_map->GetHeightmapWidth() < 64)
+    if (m_selected.size() == 1 && m_selected[0].second != -1 && m_map->GetHeightmapWidth() < 64)
     {
         m_map->InsertHeightmapRow(m_selected[0].first);
         m_selected[0].first++;
@@ -1055,7 +1055,7 @@ void HeightmapEditorCtrl::SetSelectedRestrictions(int index, uint8_t restriction
 
 bool HeightmapEditorCtrl::IsSelectedPlayerPassable() const
 {
-    for (int i = 0; i < m_selected.size(); ++i) {
+    for (size_t i = 0; i < m_selected.size(); ++i) {
         if ((GetSelectedRestrictions(i) & 0x04) != 0) {
             return false;
         }
@@ -1072,7 +1072,7 @@ void HeightmapEditorCtrl::ToggleSelectedPlayerPassable()
 
 bool HeightmapEditorCtrl::IsSelectedNPCPassable() const
 {
-    for (int i = 0; i < m_selected.size(); ++i) {
+    for (size_t i = 0; i < m_selected.size(); ++i) {
         if ((GetSelectedRestrictions(i) & 0x02) != 0) {
             return false;
         }
@@ -1089,7 +1089,7 @@ void HeightmapEditorCtrl::ToggleSelectedNPCPassable()
 
 bool HeightmapEditorCtrl::IsSelectedRaftTrack() const
 {
-    for (int i = 0; i < m_selected.size(); ++i) {
+    for (size_t i = 0; i < m_selected.size(); ++i) {
         if ((GetSelectedRestrictions(i) & 0x01) != 0) {
             return false;
         }
@@ -1099,21 +1099,21 @@ bool HeightmapEditorCtrl::IsSelectedRaftTrack() const
 
 void HeightmapEditorCtrl::ToggleSelectedRaftTrack()
 {
-    for (int i = 0; i < m_selected.size(); ++i) {
+    for (size_t i = 0; i < m_selected.size(); ++i) {
         SetSelectedRestrictions(i, GetSelectedRestrictions(i) ^ 0x01);
     }
 }
 
 void HeightmapEditorCtrl::IncrementSelectedRestrictions()
 {
-    for (int i = 0; i < m_selected.size(); ++i) {
+    for (size_t i = 0; i < m_selected.size(); ++i) {
         SetSelectedRestrictions(i, (GetSelectedRestrictions(i) + 1) & 0x0F);
     }
 }
 
 void HeightmapEditorCtrl::DecrementSelectedRestrictions()
 {
-    for (int i = 0; i < m_selected.size(); ++i) {
+    for (size_t i = 0; i < m_selected.size(); ++i) {
         SetSelectedRestrictions(i, (GetSelectedRestrictions(i) - 1) & 0x0F);
     }
 }

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1313,14 +1313,15 @@ bool HeightmapEditorCtrl::HandleRightDown(unsigned int modifiers)
     return false;
 }
 
-bool HeightmapEditorCtrl::AllSelectedMaxHeight()
+bool HeightmapEditorCtrl::AnySelectedMaxHeight()
 {
-    return std::all_of(m_selected.begin(), m_selected.end(), [&, i = 0](const auto&) mutable { return GetSelectedHeight(i++) < 15; });
+    std::cout << "AllSelectedMaxHeight" << std::endl; 
+    return std::any_of(m_selected.begin(), m_selected.end(), [&, i = 0](const auto&) mutable { return GetSelectedHeight(i++) < 15; });
 }
 
-bool HeightmapEditorCtrl::AllSelectedMinHeight()
+bool HeightmapEditorCtrl::AnySelectedMinHeight()
 {
-    return std::all_of(m_selected.begin(), m_selected.end(), [&, i = 0](const auto&) mutable { return GetSelectedHeight(i++) > 0; });
+    return std::any_of(m_selected.begin(), m_selected.end(), [&, i = 0](const auto&) mutable { return GetSelectedHeight(i++) > 0; });
 }
 
 void HeightmapEditorCtrl::RefreshStatusbar()

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1262,7 +1262,7 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
     {
         if (m_cpysrc.first != -1)
         {
-            if(m_hovered.first == m_cpysrc.first && m_hovered.second == m_cpysrc.second)
+            if(m_hovered == m_cpysrc)
             {
                 m_cpysrc = { -1, -1 };
             }

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -253,6 +253,9 @@ bool HeightmapEditorCtrl::HandleKeyDown(unsigned int key, unsigned int modifiers
         SetSelectedDoor(-1);
         FireEvent(EVT_TILESWAP_SELECT, -1);
         FireEvent(EVT_DOOR_SELECT, -1);
+        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+        RefreshStatusbar();
+        ForceRedraw();
         return true;
     }
     if (!HandleRegionKeyDown(key, modifiers))

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -768,9 +768,9 @@ bool HeightmapEditorCtrl::IsMultipleSelection() const
     return m_selected.size() > 1;
 }
 
-bool HeightmapEditorCtrl::IsSelectionValid() const
+bool HeightmapEditorCtrl::IsSelectionEmpty() const
 {
-    return !m_selected.empty();
+    return m_selected.empty();
 }
 
 void HeightmapEditorCtrl::NudgeSelectionUp()

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -35,7 +35,6 @@ HeightmapEditorCtrl::HeightmapEditorCtrl(wxWindow* parent, RoomViewerFrame* fram
       m_redraw(false),
       m_repaint(false),
       m_zoom(1.0),
-      m_selected{Coord{-1, -1}},
       m_hovered(-1, -1),
       m_cpysrc(-1, -1),
       m_dragged(-1, -1),
@@ -248,7 +247,7 @@ bool HeightmapEditorCtrl::HandleKeyDown(unsigned int key, unsigned int modifiers
     if (key == WXK_ESCAPE)
     {
         StopDrag(true);
-        m_selected[0] = { -1, -1 };
+        m_selected.clear();
         m_hovered = { -1, -1 };
         SetSelectedSwap(-1);
         SetSelectedDoor(-1);
@@ -675,11 +674,15 @@ bool HeightmapEditorCtrl::HandleDrawKeyDown(unsigned int key, unsigned int modif
         return false;
     case 'C':
     case 'c':
-        SetSelectedType(0);
+        for (size_t i = 0; i < m_selected.size(); ++i) {
+            SetSelectedType(i, 0);
+        }
         return false;
     case 'X':
     case 'x':
-        SetSelectedRestrictions(0);
+        for (size_t i = 0; i < m_selected.size(); ++i) {
+            SetSelectedRestrictions(i, 0);
+        }
         return false;
     case '0':
     case '1':
@@ -725,12 +728,9 @@ bool HeightmapEditorCtrl::HandleDrawKeyDown(unsigned int key, unsigned int modif
 
 void HeightmapEditorCtrl::ClearSelection()
 {
-    if (m_selected[0].first != -1)
-    {
-        m_selected[0] = { -1, -1 };
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        Refresh(false);
-    }
+    m_selected.clear();
+    FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+    Refresh(false);
 }
 
 void HeightmapEditorCtrl::SetSelection(int ix, int iy)
@@ -750,109 +750,121 @@ void HeightmapEditorCtrl::SetSelection(int ix, int iy)
     }
 }
 
-std::pair<int, int> HeightmapEditorCtrl::GetSelection() const
+std::pair<int, int> HeightmapEditorCtrl::GetSelection(int index) const
 {
-    return m_selected[0];
+    return m_selected[index];
 }
 
 bool HeightmapEditorCtrl::IsSelectionValid() const
 {
-    return m_selected[0].first != -1;
+    return !m_selected.empty();
 }
 
 void HeightmapEditorCtrl::NudgeSelectionUp()
 {
-    bool upd = false;
-    if (m_selected[0].first == -1 && m_hovered.first == -1)
+    if(m_selected.size() == 1)
     {
-        m_selected[0] = { 0, 0 };
-        upd = true;
-    }
-    else if (m_selected[0].first > 0)
-    {
-        if (m_selected[0].first == -1)
+        bool upd = false;
+        if (m_selected[0].first == -1 && m_hovered.first == -1)
         {
-            m_selected[0] = m_hovered;
+            m_selected[0] = { 0, 0 };
+            upd = true;
         }
-        m_selected[0].first--;
-        upd = true;
-    }
-    if (upd)
-    {
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        Refresh(false);
+        else if (m_selected[0].first > 0)
+        {
+            if (m_selected[0].first == -1)
+            {
+                m_selected[0] = m_hovered;
+            }
+            m_selected[0].first--;
+            upd = true;
+        }
+        if (upd)
+        {
+            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+            Refresh(false);
+        }
     }
 }
 
 void HeightmapEditorCtrl::NudgeSelectionDown()
 {
-    bool upd = false;
-    if (m_selected[0].first == -1 && m_hovered.first == -1)
+    if(m_selected.size() == 1)
     {
-        m_selected[0] = { 0, 0 };
-        upd = true;
-    }
-    else if (m_selected[0].first < m_map->GetHeightmapWidth() - 1)
-    {
-        if (m_selected[0].first == -1)
+        bool upd = false;
+        if (m_selected[0].first == -1 && m_hovered.first == -1)
         {
-            m_selected[0] = m_hovered;
+            m_selected[0] = { 0, 0 };
+            upd = true;
         }
-        m_selected[0].first++;
-        upd = true;
-    }
-    if (upd)
-    {
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        Refresh(false);
+        else if (m_selected[0].first < m_map->GetHeightmapWidth() - 1)
+        {
+            if (m_selected[0].first == -1)
+            {
+                m_selected[0] = m_hovered;
+            }
+            m_selected[0].first++;
+            upd = true;
+        }
+        if (upd)
+        {
+            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+            Refresh(false);
+        }
     }
 }
 
 void HeightmapEditorCtrl::NudgeSelectionLeft()
 {
-    bool upd = false;
-    if (m_selected[0].first == -1 && m_hovered.first == -1)
+    if(m_selected.size() == 1)
     {
-        m_selected[0] = { 0, 0 };
-        upd = true;
-    }
-    else if (m_selected[0].second < m_map->GetHeightmapHeight() - 1)
-    {
-        if (m_selected[0].first == -1)
+        bool upd = false;
+        if (m_selected[0].first == -1 && m_hovered.first == -1)
         {
-            m_selected[0] = m_hovered;
+            m_selected[0] = { 0, 0 };
+            upd = true;
         }
-        m_selected[0].second++;
-        upd = true;
-    }
-    if (upd)
-    {
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        Refresh(false);
+        else if (m_selected[0].second < m_map->GetHeightmapHeight() - 1)
+        {
+            if (m_selected[0].first == -1)
+            {
+                m_selected[0] = m_hovered;
+            }
+            m_selected[0].second++;
+            upd = true;
+        }
+        if (upd)
+        {
+            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+            Refresh(false);
+        }
     }
 }
 
 void HeightmapEditorCtrl::NudgeSelectionRight()
 {
-    bool upd = false;
-    if (m_selected[0].first == -1 && m_hovered.first == -1)
+    if(m_selected.size() == 1)
     {
-        m_selected[0] = { 0, 0 };
-        upd = true;
-    }
-    else if (m_selected[0].second > 0)
-    {
-        if (m_selected[0].first == -1)
+        bool upd = false;
+        if (m_selected[0].first == -1 && m_hovered.first == -1)
         {
-            m_selected[0] = m_hovered;
+            m_selected[0] = { 0, 0 };
+            upd = true;
         }
-        m_selected[0].second--;
-        upd = true;
-    }
-    if (upd)
-    {
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        Refresh(false);
+        else if (m_selected[0].second > 0)
+        {
+            if (m_selected[0].first == -1)
+            {
+                m_selected[0] = m_hovered;
+            }
+            m_selected[0].second--;
+            upd = true;
+        }
+        if (upd)
+        {
+            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+            Refresh(false);
+        }
     }
 }
 
@@ -927,69 +939,81 @@ void HeightmapEditorCtrl::InsertRowBelow()
 
 void HeightmapEditorCtrl::DeleteRow()
 {
-    if (m_selected[0].first != -1 && m_map->GetHeightmapWidth() > 1)
+    if(m_selected.size() == 1)
     {
-        m_map->DeleteHeightmapRow(m_selected[0].first);
-        if (m_selected[0].first >= m_map->GetHeightmapWidth())
+        if (m_selected[0].first != -1 && m_map->GetHeightmapWidth() > 1)
         {
-            m_selected[0].first = m_map->GetHeightmapWidth() - 1;
+            m_map->DeleteHeightmapRow(m_selected[0].first);
+            if (m_selected[0].first >= m_map->GetHeightmapWidth())
+            {
+                m_selected[0].first = m_map->GetHeightmapWidth() - 1;
+            }
+            RecreateBuffer();
+            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+            FireEvent(EVT_HEIGHTMAP_UPDATE);
+            FireEvent(EVT_PROPERTIES_UPDATE);
         }
-        RecreateBuffer();
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        FireEvent(EVT_HEIGHTMAP_UPDATE);
-        FireEvent(EVT_PROPERTIES_UPDATE);
     }
 }
 
 void HeightmapEditorCtrl::InsertColumnLeft()
 {
-    if (m_selected[0].first != -1 && m_map->GetHeightmapHeight() < 64)
+    if(m_selected.size() == 1)
     {
-        m_map->InsertHeightmapColumn(m_selected[0].second);
-        RecreateBuffer();
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        FireEvent(EVT_HEIGHTMAP_UPDATE);
-        FireEvent(EVT_PROPERTIES_UPDATE);
+        if (m_selected[0].first != -1 && m_map->GetHeightmapHeight() < 64)
+        {
+            m_map->InsertHeightmapColumn(m_selected[0].second);
+            RecreateBuffer();
+            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+            FireEvent(EVT_HEIGHTMAP_UPDATE);
+            FireEvent(EVT_PROPERTIES_UPDATE);
+        }
     }
 }
 
 void HeightmapEditorCtrl::InsertColumnRight()
 {
-    if (m_selected[0].second != -1 && m_map->GetHeightmapHeight() < 64)
+    if(m_selected.size() == 1)
     {
-        m_map->InsertHeightmapColumn(m_selected[0].second);
-        m_selected[0].second++;
-        RecreateBuffer();
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        FireEvent(EVT_HEIGHTMAP_UPDATE);
-        FireEvent(EVT_PROPERTIES_UPDATE);
+        if (m_selected[0].second != -1 && m_map->GetHeightmapHeight() < 64)
+        {
+            m_map->InsertHeightmapColumn(m_selected[0].second);
+            m_selected[0].second++;
+            RecreateBuffer();
+            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+            FireEvent(EVT_HEIGHTMAP_UPDATE);
+            FireEvent(EVT_PROPERTIES_UPDATE);
+        }
     }
 }
 
 void HeightmapEditorCtrl::DeleteColumn()
 {
-    if (m_selected[0].first != -1 && m_map->GetHeightmapHeight() > 1)
+    if(m_selected.size() == 1)
     {
-        m_map->DeleteHeightmapColumn(m_selected[0].second);
-        if (m_selected[0].second >= m_map->GetHeightmapHeight())
+        if (m_selected[0].first != -1 && m_map->GetHeightmapHeight() > 1)
         {
-            m_selected[0].second = m_map->GetHeightmapHeight() - 1;
+            m_map->DeleteHeightmapColumn(m_selected[0].second);
+            if (m_selected[0].second >= m_map->GetHeightmapHeight())
+            {
+                m_selected[0].second = m_map->GetHeightmapHeight() - 1;
+            }
+            RecreateBuffer();
+            FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
+            FireEvent(EVT_HEIGHTMAP_UPDATE);
+            FireEvent(EVT_PROPERTIES_UPDATE);
         }
-        RecreateBuffer();
-        FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        FireEvent(EVT_HEIGHTMAP_UPDATE);
-        FireEvent(EVT_PROPERTIES_UPDATE);
     }
 }
 
-uint8_t HeightmapEditorCtrl::GetSelectedHeight(int selectedIndex) const
+uint8_t HeightmapEditorCtrl::GetSelectedHeight(int index) const
 {
-    return m_map->GetHeight({ m_selected[selectedIndex].first, m_selected[selectedIndex].second });
+    return m_map->GetHeight({ m_selected[index].first, m_selected[index].second });
 }
 
-void HeightmapEditorCtrl::SetSelectedHeight(int selectedIndex, uint8_t height)
+void HeightmapEditorCtrl::SetSelectedHeight(int index, uint8_t height)
 {
-    m_map->SetHeight({ m_selected[selectedIndex].first, m_selected[selectedIndex].second }, height);
+    m_map->SetHeight({ m_selected[index].first, m_selected[index].second }, height);
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);
 }
@@ -1020,19 +1044,21 @@ void HeightmapEditorCtrl::DecreaseSelectedHeight()
 
 void HeightmapEditorCtrl::ClearSelectedCell()
 {
-    m_map->SetHeight({ m_selected[0].first, m_selected[0].second }, 0);
-    m_map->SetCellProps({ m_selected[0].first, m_selected[0].second }, 4);
-    m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, 0);
+    for (size_t i = 0; i < m_selected.size(); ++i) {
+        m_map->SetHeight({ m_selected[i].first, m_selected[0].second }, 0);
+        m_map->SetCellProps({ m_selected[i].first, m_selected[0].second }, 4);
+        m_map->SetCellType({ m_selected[i].first, m_selected[0].second }, 0);
+    }
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);
 }
 
-uint8_t HeightmapEditorCtrl::GetSelectedRestrictions() const
+uint8_t HeightmapEditorCtrl::GetSelectedRestrictions(int index) const
 {
-    return m_map->GetCellProps({ m_selected[0].first, m_selected[0].second });
+    return m_map->GetCellProps({ m_selected[index].first, m_selected[index].second });
 }
 
-void HeightmapEditorCtrl::SetSelectedRestrictions(uint8_t restrictions)
+void HeightmapEditorCtrl::SetSelectedRestrictions(int index, uint8_t restrictions)
 {
     for (const auto& coord : m_selected) {
         m_map->SetCellProps({ coord.first, coord.second }, restrictions);
@@ -1043,64 +1069,93 @@ void HeightmapEditorCtrl::SetSelectedRestrictions(uint8_t restrictions)
 
 bool HeightmapEditorCtrl::IsSelectedPlayerPassable() const
 {
-    return (GetSelectedRestrictions() & 0x04) == 0;
+    for (int i = 0; i < m_selected.size(); ++i) {
+        if ((GetSelectedRestrictions(i) & 0x04) != 0) {
+            return false;
+        }
+    }
+    return true;
 }
 
 void HeightmapEditorCtrl::ToggleSelectedPlayerPassable()
 {
-    SetSelectedRestrictions(GetSelectedRestrictions() ^ 0x04);
+    for (size_t i = 0; i < m_selected.size(); ++i) {
+        SetSelectedRestrictions(i, GetSelectedRestrictions(i) ^ 0x04);
+    }
 }
 
 bool HeightmapEditorCtrl::IsSelectedNPCPassable() const
 {
-    return (GetSelectedRestrictions() & 0x02) == 0;
+    for (int i = 0; i < m_selected.size(); ++i) {
+        if ((GetSelectedRestrictions(i) & 0x02) != 0) {
+            return false;
+        }
+    }
+    return true;
 }
 
 void HeightmapEditorCtrl::ToggleSelectedNPCPassable()
 {
-    SetSelectedRestrictions(GetSelectedRestrictions() ^ 0x02);
+    for (size_t i = 0; i < m_selected.size(); ++i) {
+        SetSelectedRestrictions(i, GetSelectedRestrictions(i) ^ 0x02);
+    }
 }
 
 bool HeightmapEditorCtrl::IsSelectedRaftTrack() const
 {
-    return (GetSelectedRestrictions() & 0x01) > 0;
+    for (int i = 0; i < m_selected.size(); ++i) {
+        if ((GetSelectedRestrictions(i) & 0x01) != 0) {
+            return false;
+        }
+    }
+    return true;
 }
 
 void HeightmapEditorCtrl::ToggleSelectedRaftTrack()
 {
-    SetSelectedRestrictions(GetSelectedRestrictions() ^ 0x01);
+    for (int i = 0; i < m_selected.size(); ++i) {
+        SetSelectedRestrictions(i, GetSelectedRestrictions(i) ^ 0x01);
+    }
 }
 
 void HeightmapEditorCtrl::IncrementSelectedRestrictions()
 {
-    SetSelectedRestrictions((GetSelectedRestrictions() + 1) & 0x0F);
+    for (int i = 0; i < m_selected.size(); ++i) {
+        SetSelectedRestrictions(i, (GetSelectedRestrictions(i) + 1) & 0x0F);
+    }
 }
 
 void HeightmapEditorCtrl::DecrementSelectedRestrictions()
 {
-    SetSelectedRestrictions((GetSelectedRestrictions() - 1) & 0x0F);
+    for (int i = 0; i < m_selected.size(); ++i) {
+        SetSelectedRestrictions(i, (GetSelectedRestrictions(i) - 1) & 0x0F);
+    }
 }
 
-uint8_t HeightmapEditorCtrl::GetSelectedType() const
+uint8_t HeightmapEditorCtrl::GetSelectedType(int index) const
 {
-    return m_map->GetCellType({m_selected[0].first, m_selected[0].second});
+    return m_map->GetCellType({m_selected[index].first, m_selected[index].second});
 }
 
-void HeightmapEditorCtrl::SetSelectedType(uint8_t type)
+void HeightmapEditorCtrl::SetSelectedType(int index, uint8_t type)
 {
-    m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, type);
+    m_map->SetCellType({ m_selected[index].first, m_selected[index].second }, type);
     ForceRedraw();
     FireEvent(EVT_HEIGHTMAP_UPDATE);
 }
 
 void HeightmapEditorCtrl::IncrementSelectedType()
 {
-    SetSelectedType((GetSelectedType() + 1) & 0xFF);
+    for (size_t i = 0; i < m_selected.size(); ++i) {
+        SetSelectedType(i, (GetSelectedType(i) + 1) & 0xFF);
+    }
 }
 
 void HeightmapEditorCtrl::DecrementSelectedType()
 {
-    SetSelectedType((GetSelectedType() - 1) & 0xFF);
+    for (size_t i = 0; i < m_selected.size(); ++i) {
+        SetSelectedType(i, (GetSelectedType(i) - 1) & 0xFF);
+    }
 }
 
 bool HeightmapEditorCtrl::HandleMouse(MouseEventType type, bool left_down, bool right_down, unsigned int modifiers, int x, int y)
@@ -1185,22 +1240,13 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
         {
             m_selected.push_back(m_hovered);
         }
-
         FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
-        if (m_cpysrc.first != -1 && m_selected[0].first != -1 && m_selected[0] != m_cpysrc)
-        {
-            m_map->SetHeight({ m_selected[0].first, m_selected[0].second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
-            m_map->SetCellProps({ m_selected[0].first, m_selected[0].second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
-            m_map->SetCellType({ m_selected[0].first, m_selected[0].second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
-            FireEvent(EVT_HEIGHTMAP_UPDATE);
-        }
         ForceRedraw();
-
     }
     else
     {
-        if (m_selected[0] != m_hovered)
-        {
+        //if (m_selected[0] != m_hovered)
+        //{
             m_selected.clear();
             m_selected.push_back(m_hovered);
             FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
@@ -1212,7 +1258,7 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
                 FireEvent(EVT_HEIGHTMAP_UPDATE);
             }
             ForceRedraw();
-        }
+        //}
     }
     return false;
 }
@@ -1653,10 +1699,10 @@ void HeightmapEditorCtrl::RecreateBuffer()
     {
         m_hovered = { -1, -1 };
     }
-    if (!IsCoordValid(m_selected[0]))
-    {
-        m_selected[0] = { -1, -1 };
-    }
+    //if (!IsCoordValid(m_selected[0]))
+    //{
+    //    m_selected[0] = { -1, -1 };
+    //}
     m_cpysrc = {-1, -1};
     RefreshGraphics();
 }

--- a/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
+++ b/src/user_interface/rooms/src/HeightmapEditorCtrl.cpp
@@ -1260,6 +1260,7 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
     }
     else
     {
+        m_selected.clear();
         if (m_cpysrc.first != -1)
         {
             if(m_hovered == m_cpysrc)
@@ -1276,7 +1277,6 @@ bool HeightmapEditorCtrl::HandleLeftDown(unsigned int modifiers)
         }
         else
         {
-            m_selected.clear();
             m_selected.push_back(m_hovered);
             FireEvent(EVT_HEIGHTMAP_CELL_SELECTED);
         }
@@ -1295,6 +1295,15 @@ bool HeightmapEditorCtrl::HandleRightDown(unsigned int modifiers)
     if ((modifiers & wxMOD_CONTROL) == 0)
     {
         m_cpysrc = m_hovered;
+
+        for (const auto& element : m_selected)
+        {
+            m_map->SetHeight({ element.first, element.second }, m_map->GetHeight({ m_cpysrc.first, m_cpysrc.second }));
+            m_map->SetCellProps({ element.first, element.second }, m_map->GetCellProps({ m_cpysrc.first, m_cpysrc.second }));
+            m_map->SetCellType({ element.first, element.second }, m_map->GetCellType({ m_cpysrc.first, m_cpysrc.second }));
+        }
+
+        FireEvent(EVT_HEIGHTMAP_UPDATE);
         Refresh(false);
     }
     else

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -2040,30 +2040,30 @@ void RoomViewerFrame::UpdateUI() const
 		EnableMenuItem(ID_EDIT_ENTITY_PROPERTIES, false);
 		EnableToolbarItem("Main", ID_EDIT_ENTITY_PROPERTIES, false);
 
-		EnableToolbarItem("Heightmap", HM_INSERT_ROW_BEFORE, !m_hmedit->IsSingleSelection());
-		EnableToolbarItem("Heightmap", HM_INSERT_ROW_AFTER, !m_hmedit->IsSingleSelection());
-		EnableToolbarItem("Heightmap", HM_DELETE_ROW, !m_hmedit->IsSingleSelection());
-		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_BEFORE, !m_hmedit->IsSingleSelection());
-		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_AFTER, !m_hmedit->IsSingleSelection());
-		EnableToolbarItem("Heightmap", HM_DELETE_COLUMN, !m_hmedit->IsSingleSelection());
-		EnableToolbarItem("Heightmap", HM_TOGGLE_PLAYER, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_TOGGLE_NPC, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->AnySelectedMaxHeight());
-		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->AnySelectedMinHeight());
+		EnableToolbarItem("Heightmap", HM_INSERT_ROW_BEFORE, m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_ROW_AFTER, m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_DELETE_ROW, m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_BEFORE, m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_AFTER, m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_DELETE_COLUMN, m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_TOGGLE_PLAYER, !m_hmedit->IsSelectionEmpty());
+		EnableToolbarItem("Heightmap", HM_TOGGLE_NPC, !m_hmedit->IsSelectionEmpty());
+		EnableToolbarItem("Heightmap", HM_TOGGLE_RAFT, !m_hmedit->IsSelectionEmpty());
+		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, !m_hmedit->IsSelectionEmpty() && m_hmedit->AnySelectedMaxHeight());
+		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, !m_hmedit->IsSelectionEmpty() && m_hmedit->AnySelectedMinHeight());
 		if (hmcell != nullptr && hmzoom != nullptr)
 		{
-			hmcell->Enable(m_hmedit->IsSelectionValid());
+			hmcell->Enable(m_hmedit->IsSelectionEmpty());
 			hmzoom->Enable(true);
 		}
 
-		CheckToolbarItem("Heightmap", HM_TOGGLE_PLAYER, m_hmedit->IsSelectionValid() && m_hmedit->IsSelectedPlayerPassable());
-		CheckToolbarItem("Heightmap", HM_TOGGLE_NPC, m_hmedit->IsSelectionValid() && !m_hmedit->IsSelectedNPCPassable());
-		CheckToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid() && m_hmedit->IsSelectedRaftTrack());
+		CheckToolbarItem("Heightmap", HM_TOGGLE_PLAYER, !m_hmedit->IsSelectionEmpty() && m_hmedit->IsSelectedPlayerPassable());
+		CheckToolbarItem("Heightmap", HM_TOGGLE_NPC, !m_hmedit->IsSelectionEmpty() && !m_hmedit->IsSelectedNPCPassable());
+		CheckToolbarItem("Heightmap", HM_TOGGLE_RAFT, !m_hmedit->IsSelectionEmpty() && m_hmedit->IsSelectedRaftTrack());
 		if (hmcell != nullptr && hmzoom != nullptr)
 		{
 			hmzoom->Enable(true);
-			if (m_hmedit->IsSelectionValid())
+			if (!m_hmedit->IsSelectionEmpty())
 			{
 				if(m_hmedit->IsMultipleSelection())
 				{

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -2062,15 +2062,24 @@ void RoomViewerFrame::UpdateUI() const
 		CheckToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid() && m_hmedit->IsSelectedRaftTrack());
 		if (hmcell != nullptr && hmzoom != nullptr)
 		{
-			hmcell->Enable(m_hmedit->IsSelectionValid());
 			hmzoom->Enable(true);
 			if (m_hmedit->IsSelectionValid())
 			{
-				//hmcell->SetSelection(m_hmedit->GetSelectedType() > 0x2F ? 0x30 : m_hmedit->GetSelectedType());
+				if(m_hmedit->IsMultipleSelection())
+				{
+					hmcell->Enable(false);
+					hmcell->SetSelection(0);
+				}
+				else
+				{
+					hmcell->Enable(true);
+					hmcell->SetSelection(m_hmedit->GetSelectedType(0) > 0x2F ? 0x30 : m_hmedit->GetSelectedType(0));
+				}
 			}
 			else
 			{
-				//hmcell->SetSelection(0);
+				hmcell->Enable(true);
+				hmcell->SetSelection(0);
 			}
 		}
 		EnableToolbarItem("Tilemap", TM_CLEAR, false);

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -2049,8 +2049,8 @@ void RoomViewerFrame::UpdateUI() const
 		EnableToolbarItem("Heightmap", HM_TOGGLE_PLAYER, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_NPC, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->AllSelectedMaxHeight());
-		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->AllSelectedMinHeight());
+		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->AnySelectedMaxHeight());
+		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->AnySelectedMinHeight());
 		if (hmcell != nullptr && hmzoom != nullptr)
 		{
 			hmcell->Enable(m_hmedit->IsSelectionValid());

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -1624,7 +1624,7 @@ void RoomViewerFrame::OnMenuClick(wxMenuEvent& evt)
 			m_hmedit->ToggleSelectedRaftTrack();
 			break;
 		case HM_INCREASE_HEIGHT:
-			m_hmedit->IncreaseSelectedHeight();
+			m_hmedit->IncreaseHeight();
 			break;
 		case HM_DECREASE_HEIGHT:
 			m_hmedit->DecreaseSelectedHeight();
@@ -2049,8 +2049,8 @@ void RoomViewerFrame::UpdateUI() const
 		EnableToolbarItem("Heightmap", HM_TOGGLE_PLAYER, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_NPC, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->GetSelectedHeight() < 15);
-		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->GetSelectedHeight() > 0);
+		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, true /*m_hmedit->IsSelectionValid() && m_hmedit->GetSelectedHeight() < 15*/);
+		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, true /*m_hmedit->IsSelectionValid() && m_hmedit->GetSelectedHeight() > 0*/);
 		if (hmcell != nullptr && hmzoom != nullptr)
 		{
 			hmcell->Enable(m_hmedit->IsSelectionValid());

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -2049,8 +2049,8 @@ void RoomViewerFrame::UpdateUI() const
 		EnableToolbarItem("Heightmap", HM_TOGGLE_PLAYER, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_NPC, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, true /*m_hmedit->IsSelectionValid() && m_hmedit->GetSelectedHeight() < 15*/);
-		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, true /*m_hmedit->IsSelectionValid() && m_hmedit->GetSelectedHeight() > 0*/);
+		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, m_hmedit->IsSelectionValid() /*&& m_hmedit->GetSelectedHeight() < 15*/);
+		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, m_hmedit->IsSelectionValid() /*&& m_hmedit->GetSelectedHeight() > 0*/);
 		if (hmcell != nullptr && hmzoom != nullptr)
 		{
 			hmcell->Enable(m_hmedit->IsSelectionValid());
@@ -2066,11 +2066,11 @@ void RoomViewerFrame::UpdateUI() const
 			hmzoom->Enable(true);
 			if (m_hmedit->IsSelectionValid())
 			{
-				hmcell->SetSelection(m_hmedit->GetSelectedType() > 0x2F ? 0x30 : m_hmedit->GetSelectedType());
+				//hmcell->SetSelection(m_hmedit->GetSelectedType() > 0x2F ? 0x30 : m_hmedit->GetSelectedType());
 			}
 			else
 			{
-				hmcell->SetSelection(0);
+				//hmcell->SetSelection(0);
 			}
 		}
 		EnableToolbarItem("Tilemap", TM_CLEAR, false);
@@ -2499,7 +2499,7 @@ void RoomViewerFrame::OnHMTypeSelect(wxCommandEvent& evt)
 	wxChoice* ctrl = static_cast<wxChoice*>(evt.GetEventObject());
 	if (ctrl != nullptr)
 	{
-		m_hmedit->SetSelectedType(ctrl->GetSelection());
+		//m_hmedit->SetSelectedType(ctrl->GetSelection());
 	}
 	UpdateUI();
 	evt.Skip();

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -2040,12 +2040,12 @@ void RoomViewerFrame::UpdateUI() const
 		EnableMenuItem(ID_EDIT_ENTITY_PROPERTIES, false);
 		EnableToolbarItem("Main", ID_EDIT_ENTITY_PROPERTIES, false);
 
-		EnableToolbarItem("Heightmap", HM_INSERT_ROW_BEFORE, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_INSERT_ROW_AFTER, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_DELETE_ROW, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_BEFORE, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_AFTER, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_DELETE_COLUMN, m_hmedit->IsSelectionValid());
+		EnableToolbarItem("Heightmap", HM_INSERT_ROW_BEFORE, !m_hmedit->IsMultipleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_ROW_AFTER, !m_hmedit->IsMultipleSelection());
+		EnableToolbarItem("Heightmap", HM_DELETE_ROW, !m_hmedit->IsMultipleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_BEFORE, !m_hmedit->IsMultipleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_AFTER, !m_hmedit->IsMultipleSelection());
+		EnableToolbarItem("Heightmap", HM_DELETE_COLUMN, !m_hmedit->IsMultipleSelection());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_PLAYER, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_NPC, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid());

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -2508,7 +2508,7 @@ void RoomViewerFrame::OnHMTypeSelect(wxCommandEvent& evt)
 	wxChoice* ctrl = static_cast<wxChoice*>(evt.GetEventObject());
 	if (ctrl != nullptr)
 	{
-		//m_hmedit->SetSelectedType(ctrl->GetSelection());
+		m_hmedit->SetSelectedType(0, ctrl->GetSelection());
 	}
 	UpdateUI();
 	evt.Skip();

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -2040,12 +2040,12 @@ void RoomViewerFrame::UpdateUI() const
 		EnableMenuItem(ID_EDIT_ENTITY_PROPERTIES, false);
 		EnableToolbarItem("Main", ID_EDIT_ENTITY_PROPERTIES, false);
 
-		EnableToolbarItem("Heightmap", HM_INSERT_ROW_BEFORE, !m_hmedit->IsMultipleSelection());
-		EnableToolbarItem("Heightmap", HM_INSERT_ROW_AFTER, !m_hmedit->IsMultipleSelection());
-		EnableToolbarItem("Heightmap", HM_DELETE_ROW, !m_hmedit->IsMultipleSelection());
-		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_BEFORE, !m_hmedit->IsMultipleSelection());
-		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_AFTER, !m_hmedit->IsMultipleSelection());
-		EnableToolbarItem("Heightmap", HM_DELETE_COLUMN, !m_hmedit->IsMultipleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_ROW_BEFORE, !m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_ROW_AFTER, !m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_DELETE_ROW, !m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_BEFORE, !m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_INSERT_COLUMN_AFTER, !m_hmedit->IsSingleSelection());
+		EnableToolbarItem("Heightmap", HM_DELETE_COLUMN, !m_hmedit->IsSingleSelection());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_PLAYER, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_NPC, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid());

--- a/src/user_interface/rooms/src/RoomViewerFrame.cpp
+++ b/src/user_interface/rooms/src/RoomViewerFrame.cpp
@@ -2049,8 +2049,8 @@ void RoomViewerFrame::UpdateUI() const
 		EnableToolbarItem("Heightmap", HM_TOGGLE_PLAYER, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_NPC, m_hmedit->IsSelectionValid());
 		EnableToolbarItem("Heightmap", HM_TOGGLE_RAFT, m_hmedit->IsSelectionValid());
-		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, m_hmedit->IsSelectionValid() /*&& m_hmedit->GetSelectedHeight() < 15*/);
-		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, m_hmedit->IsSelectionValid() /*&& m_hmedit->GetSelectedHeight() > 0*/);
+		EnableToolbarItem("Heightmap", HM_INCREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->AllSelectedMaxHeight());
+		EnableToolbarItem("Heightmap", HM_DECREASE_HEIGHT, m_hmedit->IsSelectionValid() && m_hmedit->AllSelectedMinHeight());
 		if (hmcell != nullptr && hmzoom != nullptr)
 		{
 			hmcell->Enable(m_hmedit->IsSelectionValid());


### PR DESCRIPTION
Having to click multiple time to adjust height or flags can be tedious. Now multiple cell can be selected on click with shift key pressed

* ` m_selected` is now a vector of coords
* checks has been updated accordingly, instead of checking if m_selected has a coord of -1:-1, check if the vector is empty or has multiple selection, etc
* Add/Delete row/col enable only if a singe cell is selected (same as before)
* wxChoice for cell type enable only if a single cell is selected (same as before)
* Esc key to clear selection
* If cell(s) selected when right click, cpysrc tile is copied to selected tiles (multiple copy) 
* Toggle flag change: if any cell has the flags not set, enable on all cells. Disable flags otherwise (like most software do)
